### PR TITLE
fix: CUSIP queue race condition, registration validation, and passwor…

### DIFF
--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -70,7 +70,7 @@ const validate = (schema) => {
 const schemas = {
   register: Joi.object({
     email: Joi.string().email().required(),
-    username: Joi.string().pattern(/^[a-zA-Z0-9_-]+$/).min(3).max(30).required(),
+    username: Joi.string().pattern(/^[a-zA-Z0-9_-]+$/).min(3).max(30).optional(),
     password: Joi.string().min(8).required(),
     fullName: Joi.string().max(255).allow(''),
     marketing_consent: Joi.boolean().default(false)

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -380,6 +380,10 @@ async function startServer() {
       logger.info('Skipping migrations (RUN_MIGRATIONS=false)');
     }
     
+    // Start CUSIP queue processing (after migrations have created the table)
+    const cusipQueue = require('./utils/cusipQueue');
+    cusipQueue.startProcessing();
+
     // Initialize billing service (conditional)
     await BillingService.initialize();
     

--- a/backend/src/utils/cusipQueue.js
+++ b/backend/src/utils/cusipQueue.js
@@ -407,8 +407,7 @@ Response:`;
 // Create singleton instance
 const cusipQueue = new CusipQueueManager();
 
-// Start processing on module load
-cusipQueue.startProcessing();
+// NOTE: Do not auto-start here. Processing is started in server.js after migrations complete.
 
 // Cleanup old entries daily
 setInterval(() => {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -11,9 +11,19 @@ const app = createApp(App)
 app.use(createPinia())
 app.use(router)
 
-// Initialize auth state before mounting to prevent flash of public page
-const authStore = useAuthStore()
-authStore.checkAuth().finally(() => {
+async function bootstrap() {
+  const authStore = useAuthStore()
+
+  try {
+    // Initialize auth state before mount.
+    await authStore.checkAuth()
+  } catch (error) {
+    console.error('Auth bootstrap failed:', error)
+  }
+
+  // Wait for initial navigation/redirects so public routes don't paint briefly on refresh.
+  await router.isReady()
+
   // Initialize analytics (if configured)
   const analytics = useAnalytics()
   analytics.initialize()
@@ -29,4 +39,6 @@ authStore.checkAuth().finally(() => {
   }
 
   app.mount('#app')
-})
+}
+
+bootstrap()

--- a/frontend/src/views/auth/RegisterView.vue
+++ b/frontend/src/views/auth/RegisterView.vue
@@ -59,7 +59,7 @@
               type="password"
               required
               class="input"
-              placeholder="Minimum 6 characters"
+              placeholder="Minimum 8 characters"
               @keydown.enter="handleRegister"
             />
           </div>


### PR DESCRIPTION
…d placeholder

- Start CUSIP queue after migrations complete instead of on module load to prevent "relation does not exist" error on fresh installs
- Make username optional in registration validation schema to match auto-generation in controller
- Update password placeholder from "Minimum 6 characters" to "Minimum 8 characters" to match actual validation
- Improve frontend bootstrap to await auth and router before mounting