### PR TITLE
fix: return trades array directly from parseLightspeedTransactions

### DIFF
--- a/backend/src/utils/csvParser.js
+++ b/backend/src/utils/csvParser.js
@@ -3500,7 +3500,7 @@ async function parseLightspeedTransactions(records, existingPositions = {}, user
   });
 
   console.log(`Created ${completedTrades.length} trades from ${transactions.length} transactions`);
-  return { trades: completedTrades };
+  return completedTrades;
 }
 
 async function parseSchwabTrades(records, existingPositions = {}, context = {}) {


### PR DESCRIPTION
## Summary
- `parseLightspeedTransactions` was returning `{ trades: completedTrades }` (an object) instead of `completedTrades` (the array directly), causing callers to receive an unexpected object instead of the trades array.

## Test plan
- [ ] Import a Lightspeed CSV and verify trades are parsed and saved correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)