### PR TITLE
perf: eliminate live Finnhub calls from page loads, cache analytics u…

### DIFF
--- a/backend/migrations/159_create_dashboard_news_cache.sql
+++ b/backend/migrations/159_create_dashboard_news_cache.sql
@@ -1,0 +1,13 @@
+-- Dashboard news cache table
+-- Stores pre-fetched company news from Finnhub to avoid blocking dashboard loads
+
+CREATE TABLE IF NOT EXISTS dashboard_news_cache (
+  id SERIAL PRIMARY KEY,
+  symbol VARCHAR(20) NOT NULL,
+  news_items JSONB NOT NULL DEFAULT '[]',
+  fetched_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  CONSTRAINT dashboard_news_cache_symbol_unique UNIQUE (symbol)
+);
+
+CREATE INDEX IF NOT EXISTS idx_dashboard_news_cache_symbol ON dashboard_news_cache(symbol);
+CREATE INDEX IF NOT EXISTS idx_dashboard_news_cache_fetched_at ON dashboard_news_cache(fetched_at);

--- a/backend/migrations/160_create_dashboard_earnings_cache.sql
+++ b/backend/migrations/160_create_dashboard_earnings_cache.sql
@@ -1,0 +1,13 @@
+-- Dashboard earnings cache table
+-- Stores pre-fetched earnings calendar from Finnhub to avoid blocking dashboard loads
+
+CREATE TABLE IF NOT EXISTS dashboard_earnings_cache (
+  id SERIAL PRIMARY KEY,
+  date_from DATE NOT NULL,
+  date_to DATE NOT NULL,
+  earnings_data JSONB NOT NULL DEFAULT '[]',
+  fetched_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  CONSTRAINT dashboard_earnings_cache_range_unique UNIQUE (date_from, date_to)
+);
+
+CREATE INDEX IF NOT EXISTS idx_dashboard_earnings_cache_fetched_at ON dashboard_earnings_cache(fetched_at);

--- a/backend/src/controllers/analytics.controller.js
+++ b/backend/src/controllers/analytics.controller.js
@@ -728,11 +728,9 @@ const analyticsController = {
         avg_mfe: overview.avg_mfe
       });
 
-      // Cache the result for 5 minutes (300000ms)
-      // Cache analytics overview for 5 minutes for better performance
-      const cacheTTL = 5 * 60 * 1000; // 5 minutes
+      // Cache until invalidated by trade mutations (24h fallback TTL)
+      const cacheTTL = 24 * 60 * 60 * 1000;
       cache.set(cacheKey, { overview }, cacheTTL);
-      console.log(`[CACHE SET] Analytics overview cached for ${cacheTTL/1000}s for user ${req.user.id}`);
       res.json({ overview });
     } catch (error) {
       console.error('Analytics overview error:', error);
@@ -1744,10 +1742,9 @@ const analyticsController = {
         }
       };
 
-      // Cache performance data for 5 minutes
-      const cacheTTL = 5 * 60 * 1000; // 5 minutes
+      // Cache until invalidated by trade mutations (24h fallback TTL)
+      const cacheTTL = 24 * 60 * 60 * 1000;
       cache.set(cacheKey, responseData, cacheTTL);
-      console.log(`[CACHE SET] Performance analytics cached for ${cacheTTL/1000}s`);
 
       res.json(responseData);
     } catch (error) {
@@ -2009,41 +2006,37 @@ const analyticsController = {
         const symbolResult = await db.query(symbolQuery, params);
         const symbolData = symbolResult.rows;
 
-        if (symbolData.length > 0 && finnhub.isConfigured()) {
+        if (symbolData.length > 0) {
           console.log(`[ANALYSIS] Analyzing ${symbolData.length} symbols for sector data...`);
+
+          // Read industries from symbol_categories table (populated by SymbolCategoryScheduler)
+          const symbolList = symbolData.map(s => s.symbol);
+          const catResult = await db.query(
+            `SELECT symbol, finnhub_industry FROM symbol_categories WHERE symbol = ANY($1::text[])`,
+            [symbolList]
+          );
+          const industryMap = new Map(catResult.rows.map(r => [r.symbol, r.finnhub_industry]));
+
           const sectorMap = new Map();
-          
-          // Process top symbols for sector analysis (limit to avoid delays)
-          for (const symbolInfo of symbolData.slice(0, 10)) {
-            try {
-              const profile = await finnhub.getCompanyProfile(symbolInfo.symbol);
-              
-              if (profile && profile.finnhubIndustry) {
-                const industry = profile.finnhubIndustry;
-                
-                if (!sectorMap.has(industry)) {
-                  sectorMap.set(industry, {
-                    industry: industry,
-                    total_trades: 0,
-                    total_pnl: 0,
-                    winning_trades: 0,
-                    symbols: []
-                  });
-                }
-                
-                const sector = sectorMap.get(industry);
-                sector.total_trades += parseInt(symbolInfo.total_trades);
-                sector.total_pnl += parseFloat(symbolInfo.total_pnl);
-                sector.winning_trades += parseInt(symbolInfo.winning_trades);
-                sector.symbols.push(symbolInfo.symbol);
-              }
-              
-              // Shorter delay for AI analysis
-              await new Promise(resolve => setTimeout(resolve, 1000));
-              
-            } catch (error) {
-              console.warn('[WARNING] Failed to get sector for %s:', symbolInfo.symbol, error.message);
+          for (const symbolInfo of symbolData) {
+            const industry = industryMap.get(symbolInfo.symbol);
+            if (!industry) continue;
+
+            if (!sectorMap.has(industry)) {
+              sectorMap.set(industry, {
+                industry: industry,
+                total_trades: 0,
+                total_pnl: 0,
+                winning_trades: 0,
+                symbols: []
+              });
             }
+
+            const sector = sectorMap.get(industry);
+            sector.total_trades += parseInt(symbolInfo.total_trades);
+            sector.total_pnl += parseFloat(symbolInfo.total_pnl);
+            sector.winning_trades += parseInt(symbolInfo.winning_trades);
+            sector.symbols.push(symbolInfo.symbol);
           }
 
           // Convert to array with calculated metrics
@@ -2055,7 +2048,7 @@ const analyticsController = {
 
           console.log(`[COMPLETE] Sector analysis complete: ${sectorData.length} sectors identified`);
         } else {
-          console.log('[SKIP] Skipping sector analysis - insufficient data or Finnhub not configured');
+          console.log('[SKIP] Skipping sector analysis - insufficient data');
         }
       } catch (error) {
         console.warn('[WARNING] Failed to fetch sector data for AI analysis:', error.message);
@@ -2102,13 +2095,6 @@ const analyticsController = {
   async getSectorPerformance(req, res, next) {
     try {
       console.log('[SECTOR] Starting sector performance analysis...');
-      
-      if (!finnhub.isConfigured()) {
-        console.log('[ERROR] Finnhub API key not configured');
-        return res.status(400).json({ 
-          error: 'Sector analysis not available. Finnhub API key not configured.' 
-        });
-      }
 
       // Use buildFilterConditions for consistency
       const { filterConditions, params: filterParams } = buildFilterConditions(req.query);
@@ -2237,14 +2223,9 @@ const analyticsController = {
         }
       };
 
-      // Start background categorization for uncategorized symbols (don't await)
-      if (uncategorizedSymbols.length > 0 && finnhub.isConfigured()) {
-        console.log(`[BACKGROUND] Starting background categorization for ${uncategorizedSymbols.length} symbols...`);
-        symbolCategories.getSymbolCategories(uncategorizedSymbols).then(() => {
-          console.log(`[COMPLETE] Background categorization complete for ${uncategorizedSymbols.length} symbols`);
-        }).catch(error => {
-          console.warn('[WARNING] Background categorization failed:', error.message);
-        });
+      // Uncategorized symbols will be picked up by the symbol category scheduler
+      if (uncategorizedSymbols.length > 0) {
+        console.log(`[INFO] ${uncategorizedSymbols.length} uncategorized symbols will be processed by the category scheduler`);
       }
 
       res.json(resultData);

--- a/backend/src/controllers/trade.controller.js
+++ b/backend/src/controllers/trade.controller.js
@@ -24,6 +24,7 @@ function invalidateAnalyticsCache(userId) {
   const cacheKeys = Object.keys(cache.data).filter(key =>
     key.startsWith(`analytics:user_${userId}:`) ||
     key.startsWith(`analytics_overview_${userId}_`) ||
+    key.startsWith(`analytics_chart_data_${userId}_`) ||
     key.startsWith(`performance_${userId}_`)
   );
   cacheKeys.forEach(key => cache.del(key));
@@ -3017,33 +3018,19 @@ const tradeController = {
       // Generate cache key based on userId and filters
       const cacheKey = `analytics:user_${req.user.id}:${JSON.stringify(filters)}`;
 
-      // Stale-while-revalidate: return cached data immediately, recompute in background if stale
-      const cached = cache.getStale(cacheKey);
-      if (cached.value && !cached.stale) {
-        console.log('[CACHE] Analytics cache hit (fresh) for user:', req.user.id);
-        return res.json(cached.value);
-      }
-
-      if (cached.value && cached.stale) {
-        console.log('[CACHE] Analytics cache hit (stale) for user:', req.user.id, '- returning stale, recomputing in background');
-        // Return stale data immediately
-        res.json(cached.value);
-        // Recompute in background for next request (fire-and-forget)
-        Trade.getAnalytics(req.user.id, filters).then(analytics => {
-          cache.set(cacheKey, analytics, 300000);
-          console.log('[CACHE] Background recompute complete for user:', req.user.id);
-        }).catch(err => {
-          console.error('[CACHE] Background recompute failed:', err.message);
-        });
-        return;
+      // Cache until invalidated - invalidateAnalyticsCache() clears on trade mutations
+      // (import, create, update, delete, sync). No need for time-based expiry.
+      const cached = cache.get(cacheKey);
+      if (cached) {
+        console.log('[CACHE] Analytics cache hit for user:', req.user.id);
+        return res.json(cached);
       }
 
       console.log('[CACHE] Analytics cache miss for user:', req.user.id);
       const analytics = await Trade.getAnalytics(req.user.id, filters);
 
-      // Cache the result for 5 minutes (300000ms)
-      cache.set(cacheKey, analytics, 300000);
-      console.log('[CACHE] Cached analytics for 5 minutes');
+      // Cache for 24h - effectively permanent since invalidateAnalyticsCache() clears on mutations
+      cache.set(cacheKey, analytics, 86400000);
 
       res.json(analytics);
     } catch (error) {
@@ -3538,54 +3525,49 @@ const tradeController = {
   async getTradeNews(req, res, next) {
     try {
       const { symbols } = req.query;
-      
+
       if (!symbols) {
         return res.status(400).json({ error: 'Symbols parameter is required' });
       }
 
       const symbolList = ensureString(symbols).split(',').map(s => s.trim()).filter(s => s);
-      
+
       if (symbolList.length === 0) {
         return res.json([]);
       }
 
-      const finnhub = require('../utils/finnhub');
-      
+      const NewsService = require('../services/newsService');
+      const allNews = await NewsService.getNewsForSymbols(symbolList);
+
+      res.json(allNews);
+    } catch (error) {
+      next(error);
+    }
+  },
+
+  async refreshTradeNews(req, res, next) {
+    try {
+      const { symbols } = req.body;
+
+      if (!symbols) {
+        return res.status(400).json({ error: 'Symbols parameter is required' });
+      }
+
+      const symbolList = ensureString(symbols).split(',').map(s => s.trim()).filter(s => s);
+
+      if (symbolList.length === 0) {
+        return res.json([]);
+      }
+
       if (!finnhub.isConfigured()) {
-        return res.status(503).json({ 
+        return res.status(503).json({
           error: 'News service not configured',
           details: 'Finnhub API key is required for news data. Add FINNHUB_API_KEY to your environment variables.'
         });
       }
 
-      const allNews = [];
-      const errors = [];
-
-      // Fetch news for each symbol
-      for (const symbol of symbolList) {
-        try {
-          const news = await finnhub.getCompanyNews(symbol);
-          
-          // Add symbol to each news item and filter to last 7 days
-          const enrichedNews = news
-            .map(item => ({ ...item, symbol }))
-            .filter(item => {
-              // Ensure news is from last 7 days
-              const newsDate = new Date(item.datetime * 1000);
-              const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-              return newsDate >= sevenDaysAgo;
-            })
-            .slice(0, 5); // Limit to 5 news items per symbol
-          
-          allNews.push(...enrichedNews);
-        } catch (error) {
-          console.error('Failed to fetch news for %s:', symbol, error);
-          errors.push({ symbol, error: error.message });
-        }
-      }
-
-      // Sort all news by datetime descending
-      allNews.sort((a, b) => b.datetime - a.datetime);
+      const NewsService = require('../services/newsService');
+      const allNews = await NewsService.refreshNewsForSymbols(symbolList);
 
       res.json(allNews);
     } catch (error) {
@@ -3596,48 +3578,51 @@ const tradeController = {
   async getUpcomingEarnings(req, res, next) {
     try {
       const { symbols } = req.query;
-      
+
       if (!symbols) {
         return res.status(400).json({ error: 'Symbols parameter is required' });
       }
 
       const symbolList = ensureString(symbols).split(',').map(s => s.trim()).filter(s => s);
-      
+
       if (symbolList.length === 0) {
         return res.json([]);
       }
 
-      const finnhub = require('../utils/finnhub');
-      
+      const EarningsService = require('../services/earningsService');
+      const relevantEarnings = await EarningsService.getEarningsForSymbols(symbolList);
+
+      res.json(relevantEarnings);
+    } catch (error) {
+      next(error);
+    }
+  },
+
+  async refreshUpcomingEarnings(req, res, next) {
+    try {
+      const { symbols } = req.body;
+
+      if (!symbols) {
+        return res.status(400).json({ error: 'Symbols parameter is required' });
+      }
+
+      const symbolList = ensureString(symbols).split(',').map(s => s.trim()).filter(s => s);
+
+      if (symbolList.length === 0) {
+        return res.json([]);
+      }
+
       if (!finnhub.isConfigured()) {
-        return res.status(503).json({ 
+        return res.status(503).json({
           error: 'Earnings service not configured',
           details: 'Finnhub API key is required for earnings data. Add FINNHUB_API_KEY to your environment variables.'
         });
       }
 
-      // Get earnings for next 2 weeks
-      const from = new Date().toISOString().split('T')[0];
-      const to = new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
-      
-      try {
-        // Fetch all earnings for the date range
-        const allEarnings = await finnhub.getEarningsCalendar(from, to);
-        
-        // Filter to only include symbols in user's open positions
-        const symbolSet = new Set(symbolList.map(s => s.toUpperCase()));
-        const relevantEarnings = allEarnings.filter(earning => 
-          symbolSet.has(earning.symbol.toUpperCase())
-        );
-        
-        // Sort by date
-        relevantEarnings.sort((a, b) => new Date(a.date) - new Date(b.date));
-        
-        res.json(relevantEarnings);
-      } catch (error) {
-        console.error('Failed to fetch earnings calendar:', error);
-        res.json([]); // Return empty array on error to not break the UI
-      }
+      const EarningsService = require('../services/earningsService');
+      const relevantEarnings = await EarningsService.refreshEarnings(symbolList);
+
+      res.json(relevantEarnings);
     } catch (error) {
       next(error);
     }

--- a/backend/src/controllers/watchlist.controller.js
+++ b/backend/src/controllers/watchlist.controller.js
@@ -3,6 +3,8 @@ const logger = require('../utils/logger');
 const finnhub = require('../utils/finnhub');
 const alphaVantage = require('../utils/alphaVantage');
 const { v4: uuidv4 } = require('uuid');
+const NewsService = require('../services/newsService');
+const EarningsService = require('../services/earningsService');
 
 const watchlistController = {
   // Get all watchlists for a user
@@ -436,38 +438,25 @@ const watchlistController = {
       }
       
       const symbols = symbolsResult.rows.map(row => row.symbol);
-      const allNews = [];
-      
-      // Get news for each symbol
-      for (const symbol of symbols) {
-        try {
-          const fromDate = new Date(Date.now() - parseInt(days) * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
-          const newsData = await finnhub.getCompanyNews(symbol, fromDate);
-          
-          if (newsData && newsData.length > 0) {
-            // Add symbol information to each news item
-            const symbolNews = newsData.map(article => ({
-              ...article,
-              symbol: symbol,
-              source: 'finnhub'
-            }));
-            allNews.push(...symbolNews);
-          }
-        } catch (error) {
-          logger.logWarn(`Could not fetch news for ${symbol}:`, error.message);
-        }
-      }
-      
-      // Sort by date (most recent first) and limit results
-      allNews.sort((a, b) => b.datetime - a.datetime);
-      const limitedNews = allNews.slice(0, parseInt(limit));
-      
+
+      // Read from news cache (populated by NewsScheduler)
+      let allNews = await NewsService.getNewsForSymbols(symbols);
+
+      // Post-filter by days parameter
+      const daysInt = parseInt(days);
+      const cutoff = Date.now() / 1000 - daysInt * 24 * 60 * 60;
+      allNews = allNews.filter(item => item.datetime >= cutoff);
+
+      // Apply limit
+      const limitInt = parseInt(limit);
+      const limitedNews = allNews.slice(0, limitInt);
+
       res.json({
         success: true,
         data: limitedNews,
         meta: {
           symbols: symbols,
-          days: parseInt(days),
+          days: daysInt,
           total_articles: allNews.length,
           returned_articles: limitedNews.length
         }
@@ -508,38 +497,21 @@ const watchlistController = {
       }
       
       const symbols = symbolsResult.rows.map(row => row.symbol);
-      const allEarnings = [];
-      
-      // Get earnings for each symbol
-      for (const symbol of symbols) {
-        try {
-          const fromDate = new Date().toISOString().split('T')[0];
-          const toDate = new Date(Date.now() + parseInt(days) * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
-          const earningsData = await finnhub.getEarningsCalendar(fromDate, toDate, symbol);
-          
-          if (earningsData && earningsData.length > 0) {
-            // Add symbol information to each earnings item
-            const symbolEarnings = earningsData.map(earnings => ({
-              ...earnings,
-              symbol: symbol,
-              source: 'finnhub'
-            }));
-            allEarnings.push(...symbolEarnings);
-          }
-        } catch (error) {
-          logger.logWarn(`Could not fetch earnings for ${symbol}:`, error.message);
-        }
-      }
-      
-      // Sort by date (earliest first)
-      allEarnings.sort((a, b) => new Date(a.date) - new Date(b.date));
-      
+
+      // Read from earnings cache (populated by EarningsScheduler)
+      let allEarnings = await EarningsService.getEarningsForSymbols(symbols);
+
+      // Post-filter by days parameter (earnings within N days from now)
+      const daysInt = parseInt(days);
+      const cutoffDate = new Date(Date.now() + daysInt * 24 * 60 * 60 * 1000);
+      allEarnings = allEarnings.filter(e => new Date(e.date) <= cutoffDate);
+
       res.json({
         success: true,
         data: allEarnings,
         meta: {
           symbols: symbols,
-          days: parseInt(days),
+          days: daysInt,
           total_earnings: allEarnings.length
         }
       });

--- a/backend/src/routes/trade.routes.js
+++ b/backend/src/routes/trade.routes.js
@@ -707,6 +707,7 @@ router.post('/bulk/tags', authenticate, tradeController.bulkAddTags);
  *         description: List of upcoming earnings
  */
 router.get('/earnings', authenticate, tradeController.getUpcomingEarnings);
+router.post('/earnings/refresh', authenticate, tradeController.refreshUpcomingEarnings);
 
 /**
  * @swagger
@@ -721,6 +722,7 @@ router.get('/earnings', authenticate, tradeController.getUpcomingEarnings);
  *         description: List of trade-related news
  */
 router.get('/news', authenticate, tradeController.getTradeNews);
+router.post('/news/refresh', authenticate, tradeController.refreshTradeNews);
 
 // Export trades - MUST be before /:id route to avoid matching "export" as an ID
 router.get('/export', authenticate, tradeController.exportTrades);

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -60,6 +60,9 @@ const RetentionEmailScheduler = require('./services/retentionEmailScheduler');
 const OptionsScheduler = require('./services/optionsScheduler');
 const brokerSyncScheduler = require('./services/brokerSync/brokerSyncScheduler');
 const dividendScheduler = require('./services/dividendScheduler');
+const newsScheduler = require('./services/newsScheduler');
+const earningsScheduler = require('./services/earningsScheduler');
+const symbolCategoryScheduler = require('./services/symbolCategoryScheduler');
 const webhookEventBridge = require('./services/webhookEventBridge');
 const backgroundWorker = require('./workers/backgroundWorker');
 const jobRecoveryService = require('./services/jobRecoveryService');
@@ -457,6 +460,33 @@ async function startServer() {
       console.log('Dividend scheduler disabled (ENABLE_DIVIDEND_SCHEDULER=false)');
     }
 
+    // Start news scheduler (pre-fetches company news for dashboard)
+    if (process.env.ENABLE_NEWS_SCHEDULER !== 'false') {
+      console.log('Starting news scheduler...');
+      newsScheduler.start();
+      console.log('[SUCCESS] News scheduler started');
+    } else {
+      console.log('News scheduler disabled (ENABLE_NEWS_SCHEDULER=false)');
+    }
+
+    // Start earnings scheduler (pre-fetches earnings calendar for dashboard)
+    if (process.env.ENABLE_EARNINGS_SCHEDULER !== 'false') {
+      console.log('Starting earnings scheduler...');
+      earningsScheduler.start();
+      console.log('[SUCCESS] Earnings scheduler started');
+    } else {
+      console.log('Earnings scheduler disabled (ENABLE_EARNINGS_SCHEDULER=false)');
+    }
+
+    // Start symbol category scheduler (pre-categorizes traded symbols with industry data)
+    if (process.env.ENABLE_CATEGORY_SCHEDULER !== 'false') {
+      console.log('Starting symbol category scheduler...');
+      symbolCategoryScheduler.start();
+      console.log('[SUCCESS] Symbol category scheduler started');
+    } else {
+      console.log('Symbol category scheduler disabled (ENABLE_CATEGORY_SCHEDULER=false)');
+    }
+
     if (process.env.ENABLE_V1_WEBHOOKS === 'true') {
       webhookEventBridge.start();
     }
@@ -569,6 +599,9 @@ process.on('SIGTERM', async () => {
   await priceMonitoringService.stop();
   OptionsScheduler.stop();
   brokerSyncScheduler.stop();
+  newsScheduler.stop();
+  earningsScheduler.stop();
+  symbolCategoryScheduler.stop();
   if (typeof GamificationScheduler.stopScheduler === 'function') GamificationScheduler.stopScheduler();
   if (typeof TrialScheduler.stopScheduler === 'function') TrialScheduler.stopScheduler();
   if (RetentionEmailScheduler.stopScheduler) RetentionEmailScheduler.stopScheduler();
@@ -587,6 +620,9 @@ process.on('SIGINT', async () => {
   await priceMonitoringService.stop();
   OptionsScheduler.stop();
   brokerSyncScheduler.stop();
+  newsScheduler.stop();
+  earningsScheduler.stop();
+  symbolCategoryScheduler.stop();
   if (typeof GamificationScheduler.stopScheduler === 'function') GamificationScheduler.stopScheduler();
   if (typeof TrialScheduler.stopScheduler === 'function') TrialScheduler.stopScheduler();
   if (RetentionEmailScheduler.stopScheduler) RetentionEmailScheduler.stopScheduler();

--- a/backend/src/services/earningsScheduler.js
+++ b/backend/src/services/earningsScheduler.js
@@ -1,0 +1,116 @@
+/**
+ * Earnings Scheduler
+ * Runs periodically to pre-fetch and cache the earnings calendar
+ *
+ * Default schedule: Every 4 hours
+ * - Fetches 2-week earnings calendar from Finnhub (single API call)
+ * - Stores results in dashboard_earnings_cache table
+ * - Cleans up stale cache entries
+ */
+
+const EarningsService = require('./earningsService');
+
+const CHECK_INTERVAL = 4 * 60 * 60 * 1000; // Run every 4 hours
+
+class EarningsScheduler {
+  constructor() {
+    this.interval = null;
+    this.isRunning = false;
+    this.lastRunDate = null;
+  }
+
+  /**
+   * Fetch and cache earnings calendar
+   */
+  async processEarnings() {
+    if (this.isRunning) {
+      console.log('[EARNINGS-SCHEDULER] Previous run still in progress, skipping...');
+      return;
+    }
+
+    this.isRunning = true;
+    const logPrefix = '[EARNINGS-SCHEDULER]';
+
+    try {
+      console.log(`${logPrefix} Starting scheduled earnings fetch...`);
+
+      const result = await EarningsService.fetchAndCache();
+
+      // Clean up old entries
+      await EarningsService.cleanupOldEntries();
+
+      this.lastRunDate = new Date().toISOString();
+
+      if (result !== null) {
+        console.log(`${logPrefix} Earnings fetch complete - ${result.length} entries cached`);
+      } else {
+        console.log(`${logPrefix} Earnings fetch failed, will retry next cycle`);
+      }
+
+      return result;
+    } catch (error) {
+      console.error(`${logPrefix} [ERROR] Scheduler error:`, error);
+    } finally {
+      this.isRunning = false;
+    }
+  }
+
+  /**
+   * Start the scheduler
+   */
+  start() {
+    console.log('[EARNINGS-SCHEDULER] Starting earnings scheduler...');
+    console.log('[EARNINGS-SCHEDULER] Scheduled to run every 4 hours');
+
+    // Run immediately on start to populate cache
+    this.processEarnings().catch(error => {
+      console.error('[EARNINGS-SCHEDULER] Initial run failed:', error);
+    });
+
+    // Schedule periodic runs
+    this.interval = setInterval(() => {
+      this.processEarnings().catch(error => {
+        console.error('[EARNINGS-SCHEDULER] Scheduled run failed:', error);
+      });
+    }, CHECK_INTERVAL);
+
+    console.log('[EARNINGS-SCHEDULER] Scheduler started');
+  }
+
+  /**
+   * Stop the scheduler
+   */
+  stop() {
+    console.log('[EARNINGS-SCHEDULER] Stopping earnings scheduler...');
+
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+
+    console.log('[EARNINGS-SCHEDULER] Scheduler stopped');
+  }
+
+  /**
+   * Force run now (for manual triggering/testing)
+   */
+  async runNow() {
+    console.log('[EARNINGS-SCHEDULER] Manual run triggered...');
+    return await this.processEarnings();
+  }
+
+  /**
+   * Get scheduler status
+   */
+  getStatus() {
+    return {
+      running: this.interval !== null,
+      processing: this.isRunning,
+      checkIntervalMinutes: CHECK_INTERVAL / 60000,
+      lastRunDate: this.lastRunDate
+    };
+  }
+}
+
+// Export singleton instance
+module.exports = new EarningsScheduler();

--- a/backend/src/services/earningsService.js
+++ b/backend/src/services/earningsService.js
@@ -1,0 +1,131 @@
+/**
+ * Earnings Service
+ * Handles fetching and caching earnings calendar data for the dashboard
+ *
+ * - Fetches earnings calendar from Finnhub for a 2-week window
+ * - Caches full calendar in dashboard_earnings_cache table
+ * - Serves cached data to dashboard for instant loading
+ */
+
+const db = require('../config/database');
+const finnhub = require('../utils/finnhub');
+
+const LOG_PREFIX = '[EARNINGS-SERVICE]';
+
+class EarningsService {
+  /**
+   * Get the current 2-week date range used for earnings lookups
+   */
+  static getDateRange() {
+    const from = new Date().toISOString().split('T')[0];
+    const to = new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+    return { from, to };
+  }
+
+  /**
+   * Get cached earnings for the current 2-week window
+   */
+  static async getCachedEarnings() {
+    const { from, to } = this.getDateRange();
+
+    const result = await db.query(
+      `SELECT earnings_data, fetched_at
+       FROM dashboard_earnings_cache
+       WHERE date_from = $1 AND date_to = $2`,
+      [from, to]
+    );
+
+    if (result.rows.length === 0) return null;
+    return result.rows[0];
+  }
+
+  /**
+   * Fetch earnings from Finnhub and update cache
+   */
+  static async fetchAndCache() {
+    const { from, to } = this.getDateRange();
+
+    try {
+      const allEarnings = await finnhub.getEarningsCalendar(from, to);
+
+      // Upsert into cache
+      await db.query(
+        `INSERT INTO dashboard_earnings_cache (date_from, date_to, earnings_data, fetched_at)
+         VALUES ($1, $2, $3, NOW())
+         ON CONFLICT (date_from, date_to)
+         DO UPDATE SET earnings_data = $3, fetched_at = NOW()`,
+        [from, to, JSON.stringify(allEarnings)]
+      );
+
+      console.log(`${LOG_PREFIX} Cached ${allEarnings.length} earnings entries for ${from} to ${to}`);
+      return allEarnings;
+    } catch (error) {
+      console.error(`${LOG_PREFIX} Failed to fetch earnings calendar:`, error.message);
+      return null;
+    }
+  }
+
+  /**
+   * Get earnings for specific symbols, using cache with live fallback
+   */
+  static async getEarningsForSymbols(symbolList) {
+    const symbolSet = new Set(symbolList.map(s => s.toUpperCase()));
+
+    // Try cache first
+    const cached = await this.getCachedEarnings();
+
+    let allEarnings;
+    if (cached) {
+      allEarnings = Array.isArray(cached.earnings_data) ? cached.earnings_data : [];
+    } else {
+      // Fallback: fetch live and populate cache (fresh install scenario)
+      if (!finnhub.isConfigured()) return [];
+
+      console.log(`${LOG_PREFIX} Cache miss, fetching live...`);
+      const fetched = await this.fetchAndCache();
+      allEarnings = fetched || [];
+    }
+
+    // Filter to user's symbols
+    const relevant = allEarnings.filter(earning =>
+      earning.symbol && symbolSet.has(earning.symbol.toUpperCase())
+    );
+
+    // Sort by date
+    relevant.sort((a, b) => new Date(a.date) - new Date(b.date));
+
+    return relevant;
+  }
+
+  /**
+   * Force refresh earnings (manual refresh)
+   */
+  static async refreshEarnings(symbolList) {
+    if (!finnhub.isConfigured()) return [];
+
+    const fetched = await this.fetchAndCache();
+    if (!fetched) return [];
+
+    const symbolSet = new Set(symbolList.map(s => s.toUpperCase()));
+    const relevant = fetched.filter(earning =>
+      earning.symbol && symbolSet.has(earning.symbol.toUpperCase())
+    );
+
+    relevant.sort((a, b) => new Date(a.date) - new Date(b.date));
+    return relevant;
+  }
+
+  /**
+   * Clean up old cache entries (older than 3 days)
+   */
+  static async cleanupOldEntries() {
+    const result = await db.query(
+      `DELETE FROM dashboard_earnings_cache WHERE fetched_at < NOW() - INTERVAL '3 days'`
+    );
+    if (result.rowCount > 0) {
+      console.log(`${LOG_PREFIX} Cleaned up ${result.rowCount} stale cache entries`);
+    }
+  }
+}
+
+module.exports = EarningsService;

--- a/backend/src/services/newsScheduler.js
+++ b/backend/src/services/newsScheduler.js
@@ -1,0 +1,119 @@
+/**
+ * News Scheduler
+ * Runs periodically to pre-fetch and cache company news for open positions
+ *
+ * Default schedule: Every hour
+ * - Queries all distinct symbols with open trades
+ * - Fetches news from Finnhub with rate-limit-respecting delays
+ * - Stores results in dashboard_news_cache table
+ * - Skips symbols already fetched within the last hour
+ */
+
+const NewsService = require('./newsService');
+
+const CHECK_INTERVAL = 60 * 60 * 1000; // Run every hour
+
+class NewsScheduler {
+  constructor() {
+    this.interval = null;
+    this.isRunning = false;
+    this.lastRunDate = null;
+  }
+
+  /**
+   * Process news for all open position symbols
+   */
+  async processNews() {
+    if (this.isRunning) {
+      console.log('[NEWS-SCHEDULER] Previous run still in progress, skipping...');
+      return;
+    }
+
+    this.isRunning = true;
+    const logPrefix = '[NEWS-SCHEDULER]';
+
+    try {
+      console.log(`${logPrefix} Starting scheduled news fetch...`);
+
+      const symbols = await NewsService.getAllTrackedSymbols();
+
+      if (symbols.length === 0) {
+        console.log(`${logPrefix} No tracked symbols found, skipping news fetch`);
+        this.lastRunDate = new Date().toISOString();
+        return;
+      }
+
+      console.log(`${logPrefix} Found ${symbols.length} tracked symbols (open positions + watchlists)`);
+
+      const summary = await NewsService.fetchAndCacheAll(symbols);
+
+      this.lastRunDate = new Date().toISOString();
+
+      console.log(`${logPrefix} News fetch complete - fetched: ${summary.fetched}, skipped (cached): ${summary.skipped}, errors: ${summary.errors}`);
+      return summary;
+    } catch (error) {
+      console.error(`${logPrefix} [ERROR] Scheduler error:`, error);
+    } finally {
+      this.isRunning = false;
+    }
+  }
+
+  /**
+   * Start the scheduler
+   */
+  start() {
+    console.log('[NEWS-SCHEDULER] Starting news scheduler...');
+    console.log('[NEWS-SCHEDULER] Scheduled to run every hour');
+
+    // Run immediately on start to populate cache
+    this.processNews().catch(error => {
+      console.error('[NEWS-SCHEDULER] Initial run failed:', error);
+    });
+
+    // Schedule hourly runs
+    this.interval = setInterval(() => {
+      this.processNews().catch(error => {
+        console.error('[NEWS-SCHEDULER] Scheduled run failed:', error);
+      });
+    }, CHECK_INTERVAL);
+
+    console.log('[NEWS-SCHEDULER] Scheduler started');
+  }
+
+  /**
+   * Stop the scheduler
+   */
+  stop() {
+    console.log('[NEWS-SCHEDULER] Stopping news scheduler...');
+
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+
+    console.log('[NEWS-SCHEDULER] Scheduler stopped');
+  }
+
+  /**
+   * Force run now (for manual triggering/testing)
+   */
+  async runNow() {
+    console.log('[NEWS-SCHEDULER] Manual run triggered...');
+    return await this.processNews();
+  }
+
+  /**
+   * Get scheduler status
+   */
+  getStatus() {
+    return {
+      running: this.interval !== null,
+      processing: this.isRunning,
+      checkIntervalMinutes: CHECK_INTERVAL / 60000,
+      lastRunDate: this.lastRunDate
+    };
+  }
+}
+
+// Export singleton instance
+module.exports = new NewsScheduler();

--- a/backend/src/services/newsService.js
+++ b/backend/src/services/newsService.js
@@ -1,0 +1,200 @@
+/**
+ * News Service
+ * Handles fetching and caching company news for the dashboard
+ *
+ * - Fetches company news from Finnhub for open position symbols
+ * - Caches results in dashboard_news_cache table
+ * - Serves cached news to dashboard for instant loading
+ */
+
+const db = require('../config/database');
+const finnhub = require('../utils/finnhub');
+
+const LOG_PREFIX = '[NEWS-SERVICE]';
+
+// Cache staleness threshold (1 hour)
+const CACHE_MAX_AGE_MS = 60 * 60 * 1000;
+
+// Delay between Finnhub API calls to respect rate limits (300ms)
+const API_DELAY_MS = 300;
+
+class NewsService {
+  /**
+   * Get all distinct symbols with open trades or in watchlists across all users
+   */
+  static async getAllTrackedSymbols() {
+    const query = `
+      SELECT DISTINCT symbol FROM (
+        SELECT symbol FROM trades
+        WHERE exit_price IS NULL AND symbol IS NOT NULL AND symbol != ''
+        UNION
+        SELECT symbol FROM watchlist_items
+        WHERE symbol IS NOT NULL AND symbol != ''
+      ) combined
+      ORDER BY symbol
+    `;
+
+    const result = await db.query(query);
+    return result.rows.map(row => row.symbol);
+  }
+
+  /**
+   * Get cached news for a list of symbols
+   */
+  static async getCachedNews(symbols) {
+    if (!symbols || symbols.length === 0) return [];
+
+    const placeholders = symbols.map((_, i) => `$${i + 1}`).join(',');
+    const query = `
+      SELECT symbol, news_items, fetched_at
+      FROM dashboard_news_cache
+      WHERE symbol IN (${placeholders})
+    `;
+
+    const result = await db.query(query, symbols);
+    return result.rows;
+  }
+
+  /**
+   * Fetch news from Finnhub for a single symbol and update cache
+   */
+  static async fetchAndCacheSymbol(symbol) {
+    try {
+      const news = await finnhub.getCompanyNews(symbol);
+
+      // Filter to last 7 days and limit to 5 per symbol
+      const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+      const filtered = news
+        .filter(item => {
+          const newsDate = new Date(item.datetime * 1000);
+          return newsDate >= sevenDaysAgo;
+        })
+        .slice(0, 5)
+        .map(item => ({ ...item, symbol }));
+
+      // Upsert into cache
+      await db.query(
+        `INSERT INTO dashboard_news_cache (symbol, news_items, fetched_at)
+         VALUES ($1, $2, NOW())
+         ON CONFLICT (symbol)
+         DO UPDATE SET news_items = $2, fetched_at = NOW()`,
+        [symbol, JSON.stringify(filtered)]
+      );
+
+      return filtered;
+    } catch (error) {
+      console.error(`${LOG_PREFIX} Failed to fetch news for ${symbol}:`, error.message);
+      return null;
+    }
+  }
+
+  /**
+   * Fetch and cache news for multiple symbols with rate limiting
+   */
+  static async fetchAndCacheAll(symbols) {
+    let fetched = 0;
+    let skipped = 0;
+    let errors = 0;
+
+    for (const symbol of symbols) {
+      // Check if already cached recently
+      const cached = await db.query(
+        `SELECT fetched_at FROM dashboard_news_cache
+         WHERE symbol = $1 AND fetched_at > NOW() - INTERVAL '1 hour'`,
+        [symbol]
+      );
+
+      if (cached.rows.length > 0) {
+        skipped++;
+        continue;
+      }
+
+      const result = await this.fetchAndCacheSymbol(symbol);
+      if (result !== null) {
+        fetched++;
+      } else {
+        errors++;
+      }
+
+      // Rate limit delay between API calls
+      if (symbols.indexOf(symbol) < symbols.length - 1) {
+        await new Promise(resolve => setTimeout(resolve, API_DELAY_MS));
+      }
+    }
+
+    return { fetched, skipped, errors, total: symbols.length };
+  }
+
+  /**
+   * Get cached news formatted for the frontend (same shape as existing endpoint)
+   * Falls back to live fetch if no cache exists
+   */
+  static async getNewsForSymbols(symbols) {
+    if (!symbols || symbols.length === 0) return [];
+
+    const cached = await this.getCachedNews(symbols);
+
+    // Collect all news items from cache
+    const allNews = [];
+    const uncachedSymbols = [];
+
+    const cachedSymbolSet = new Set(cached.map(r => r.symbol));
+
+    for (const row of cached) {
+      const items = Array.isArray(row.news_items) ? row.news_items : [];
+      allNews.push(...items);
+    }
+
+    // Find symbols not in cache
+    for (const symbol of symbols) {
+      if (!cachedSymbolSet.has(symbol)) {
+        uncachedSymbols.push(symbol);
+      }
+    }
+
+    // Fallback: fetch uncached symbols live (fresh install scenario)
+    if (uncachedSymbols.length > 0 && finnhub.isConfigured()) {
+      console.log(`${LOG_PREFIX} Cache miss for ${uncachedSymbols.length} symbols, fetching live...`);
+      for (const symbol of uncachedSymbols) {
+        const items = await this.fetchAndCacheSymbol(symbol);
+        if (items) {
+          allNews.push(...items);
+        }
+        // Rate limit
+        if (uncachedSymbols.indexOf(symbol) < uncachedSymbols.length - 1) {
+          await new Promise(resolve => setTimeout(resolve, API_DELAY_MS));
+        }
+      }
+    }
+
+    // Sort all news by datetime descending
+    allNews.sort((a, b) => b.datetime - a.datetime);
+
+    return allNews;
+  }
+
+  /**
+   * Force refresh news for specific symbols (manual refresh button)
+   */
+  static async refreshNewsForSymbols(symbols) {
+    if (!symbols || symbols.length === 0) return [];
+
+    const allNews = [];
+
+    for (const symbol of symbols) {
+      const items = await this.fetchAndCacheSymbol(symbol);
+      if (items) {
+        allNews.push(...items);
+      }
+      // Rate limit
+      if (symbols.indexOf(symbol) < symbols.length - 1) {
+        await new Promise(resolve => setTimeout(resolve, API_DELAY_MS));
+      }
+    }
+
+    allNews.sort((a, b) => b.datetime - a.datetime);
+    return allNews;
+  }
+}
+
+module.exports = NewsService;

--- a/backend/src/services/symbolCategoryScheduler.js
+++ b/backend/src/services/symbolCategoryScheduler.js
@@ -1,0 +1,114 @@
+/**
+ * Symbol Category Scheduler
+ * Runs periodically to pre-categorize all traded symbols with industry data
+ *
+ * Default schedule: Every 6 hours
+ * - Finds symbols in trades that don't have categories in symbol_categories table
+ * - Fetches company profiles from Finnhub (industry, sector, company name)
+ * - Stores results permanently in symbol_categories table
+ * - Once a symbol is categorized, it never needs re-fetching (company sector doesn't change)
+ */
+
+const symbolCategories = require('../utils/symbolCategories');
+
+const CHECK_INTERVAL = 6 * 60 * 60 * 1000; // Run every 6 hours
+
+class SymbolCategoryScheduler {
+  constructor() {
+    this.interval = null;
+    this.isRunning = false;
+    this.lastRunDate = null;
+  }
+
+  /**
+   * Categorize uncategorized symbols
+   */
+  async processCategories() {
+    if (this.isRunning) {
+      console.log('[CATEGORY-SCHEDULER] Previous run still in progress, skipping...');
+      return;
+    }
+
+    this.isRunning = true;
+    const logPrefix = '[CATEGORY-SCHEDULER]';
+
+    try {
+      console.log(`${logPrefix} Starting scheduled symbol categorization...`);
+
+      const result = await symbolCategories.categorizeNewSymbols();
+
+      this.lastRunDate = new Date().toISOString();
+
+      if (result.total === 0) {
+        console.log(`${logPrefix} All symbols already categorized`);
+      } else {
+        console.log(`${logPrefix} Categorization complete - processed: ${result.processed}/${result.total}`);
+      }
+
+      return result;
+    } catch (error) {
+      console.error(`${logPrefix} [ERROR] Scheduler error:`, error);
+    } finally {
+      this.isRunning = false;
+    }
+  }
+
+  /**
+   * Start the scheduler
+   */
+  start() {
+    console.log('[CATEGORY-SCHEDULER] Starting symbol category scheduler...');
+    console.log('[CATEGORY-SCHEDULER] Scheduled to run every 6 hours');
+
+    // Run immediately on start to categorize any new symbols
+    this.processCategories().catch(error => {
+      console.error('[CATEGORY-SCHEDULER] Initial run failed:', error);
+    });
+
+    // Schedule periodic runs
+    this.interval = setInterval(() => {
+      this.processCategories().catch(error => {
+        console.error('[CATEGORY-SCHEDULER] Scheduled run failed:', error);
+      });
+    }, CHECK_INTERVAL);
+
+    console.log('[CATEGORY-SCHEDULER] Scheduler started');
+  }
+
+  /**
+   * Stop the scheduler
+   */
+  stop() {
+    console.log('[CATEGORY-SCHEDULER] Stopping symbol category scheduler...');
+
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+
+    console.log('[CATEGORY-SCHEDULER] Scheduler stopped');
+  }
+
+  /**
+   * Force run now (for manual triggering/testing)
+   */
+  async runNow() {
+    console.log('[CATEGORY-SCHEDULER] Manual run triggered...');
+    return await this.processCategories();
+  }
+
+  /**
+   * Get scheduler status
+   */
+  getStatus() {
+    return {
+      running: this.interval !== null,
+      processing: this.isRunning,
+      checkIntervalMinutes: CHECK_INTERVAL / 60000,
+      lastRunDate: this.lastRunDate
+    };
+  }
+}
+
+// Export singleton instance
+module.exports = new SymbolCategoryScheduler();

--- a/frontend/src/components/dashboard/TradeNewsSection.vue
+++ b/frontend/src/components/dashboard/TradeNewsSection.vue
@@ -187,8 +187,24 @@ const fetchNews = async () => {
   }
 }
 
-const refreshNews = () => {
-  fetchNews()
+const refreshNews = async () => {
+  if (!props.symbols.length) return
+
+  loading.value = true
+  error.value = null
+
+  try {
+    const response = await api.post('/trades/news/refresh', {
+      symbols: props.symbols.join(',')
+    })
+
+    newsItems.value = response.data
+  } catch (err) {
+    console.error('Failed to refresh news:', err)
+    error.value = err.response?.data?.error || 'Failed to refresh news. Please try again later.'
+  } finally {
+    loading.value = false
+  }
 }
 
 onMounted(() => {

--- a/frontend/src/components/dashboard/UpcomingEarningsSection.vue
+++ b/frontend/src/components/dashboard/UpcomingEarningsSection.vue
@@ -3,7 +3,30 @@
     <div class="card-body">
       <div class="flex items-center justify-between mb-4">
         <h3 class="text-lg font-medium text-gray-900 dark:text-white">Upcoming Earnings</h3>
-        <span class="text-xs text-gray-500 dark:text-gray-400">Next 2 weeks</span>
+        <div class="flex items-center space-x-2">
+          <span class="text-xs text-gray-500 dark:text-gray-400">Next 2 weeks</span>
+          <button
+            @click="refreshEarnings"
+            :disabled="loading"
+            class="inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <svg
+              class="w-4 h-4 mr-1.5"
+              :class="{ 'animate-spin': loading }"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+              />
+            </svg>
+            Refresh
+          </button>
+        </div>
       </div>
 
       <div v-if="loading && !earnings.length" class="flex justify-center py-8">
@@ -170,6 +193,42 @@ const fetchEarnings = async () => {
   } catch (err) {
     console.error('Failed to fetch earnings:', err)
     error.value = err.response?.data?.error || 'Failed to load earnings data. Please try again later.'
+  } finally {
+    loading.value = false
+  }
+}
+
+const refreshEarnings = async () => {
+  if (!props.symbols.length) return
+
+  loading.value = true
+  error.value = null
+
+  try {
+    const response = await api.post('/trades/earnings/refresh', {
+      symbols: props.symbols.join(',')
+    })
+
+    const now = new Date()
+    now.setHours(0, 0, 0, 0)
+
+    earnings.value = response.data
+      .map(earning => {
+        const earningsDate = new Date(earning.date)
+        earningsDate.setHours(0, 0, 0, 0)
+        const diffTime = earningsDate - now
+        const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24))
+
+        return {
+          ...earning,
+          daysUntil: diffDays
+        }
+      })
+      .filter(earning => earning.daysUntil >= 0 && earning.daysUntil <= 14)
+      .sort((a, b) => a.daysUntil - b.daysUntil)
+  } catch (err) {
+    console.error('Failed to refresh earnings:', err)
+    error.value = err.response?.data?.error || 'Failed to refresh earnings data. Please try again later.'
   } finally {
     loading.value = false
   }

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1585,36 +1585,57 @@ function getDateRange(range) {
   }
 }
 
+function getAnalyticsCacheKey() {
+  const dateRange = getDateRange(filters.value.timeRange)
+  const parts = [dateRange.startDate || '', dateRange.endDate || '', selectedAccount.value || '']
+  return 'dashboard_analytics_' + parts.join('_')
+}
+
+function loadCachedAnalytics() {
+  try {
+    const key = getAnalyticsCacheKey()
+    const stored = sessionStorage.getItem(key)
+    if (stored) {
+      const data = JSON.parse(stored)
+      analytics.value = data
+      analyticsLoading.value = false
+      nextTick(() => createCharts())
+      return true
+    }
+  } catch (e) {
+    // sessionStorage read failed
+  }
+  return false
+}
+
 async function fetchAnalytics() {
   try {
-    analyticsLoading.value = true
+    // Only show skeleton if we have no cached data to display
+    if (!analytics.value?.summary?.totalTrades && analytics.value?.summary?.totalTrades !== 0) {
+      analyticsLoading.value = true
+    }
 
     const dateRange = getDateRange(filters.value.timeRange)
     const params = new URLSearchParams()
-    
+
     // Only add parameters if they have values
     if (dateRange.startDate) params.append('startDate', dateRange.startDate)
     if (dateRange.endDate) params.append('endDate', dateRange.endDate)
     // Use global account filter
     if (selectedAccount.value) params.append('accounts', selectedAccount.value)
-    
-    console.log('Dashboard: Fetching analytics with params:', params.toString())
+
     const response = await api.get(`/trades/analytics?${params}`)
     analytics.value = response.data
-    
-    console.log('Dashboard: Analytics response:', analytics.value)
-    console.log('Dashboard: Daily P&L data length:', analytics.value.dailyPnL?.length)
-    console.log('Dashboard: Daily P&L data:', analytics.value.dailyPnL)
-    console.log('Dashboard: Summary data:', analytics.value.summary)
-    console.log('Dashboard: Top trades data:', analytics.value.topTrades)
-    console.log('Dashboard: Win/Loss counts:', {
-      wins: analytics.value.summary?.winningTrades,
-      losses: analytics.value.summary?.losingTrades,
-      breakeven: analytics.value.summary?.breakevenTrades
-    })
-    
+
+    // Persist to sessionStorage for instant display on page reload
+    try {
+      const key = getAnalyticsCacheKey()
+      sessionStorage.setItem(key, JSON.stringify(response.data))
+    } catch (e) {
+      // sessionStorage write failed (quota, private mode, etc.)
+    }
+
     await nextTick()
-    // Create charts immediately without artificial delay
     createCharts()
   } catch (error) {
     console.error('Failed to fetch analytics:', error)
@@ -2379,6 +2400,9 @@ onMounted(async () => {
     // localStorage load failed
   }
 
+  // Try to restore analytics from sessionStorage for instant chart rendering
+  const hasCachedAnalytics = loadCachedAnalytics()
+
   // Phase 1: Fetch settings + positions in parallel (both fast) to show dashboard shell ASAP
   await Promise.all([
     fetchUserSettings(),
@@ -2388,7 +2412,8 @@ onMounted(async () => {
   // Dashboard shell is ready - drop the full-page spinner
   initialLoading.value = false
 
-  // Phase 2: Fire all remaining data fetches non-blocking (analytics is heavy, quotes are slow)
+  // Phase 2: Fire all remaining data fetches non-blocking
+  // If we had cached analytics, this silently refreshes in background; otherwise it loads fresh
   fetchAnalytics()
   fetchOpenTradeQuotes()
   fetchExpiredOptionsCount()


### PR DESCRIPTION
…ntil invalidated

- Watchlist news/earnings endpoints now read from NewsService/EarningsService cache instead of looping through Finnhub API calls per symbol
- News scheduler expanded to pre-fetch watchlist symbols alongside open positions
- AI recommendations sector lookup reads symbol_categories table instead of calling getCompanyProfile() with 1-second delays per symbol
- Analytics cache changed from 5-minute TTL to invalidation-only (24h fallback); cache is already cleared on every trade mutation (import/create/update/delete)
- Added analytics_chart_data_ prefix to cache invalidation (was previously missed)
- Dashboard analytics persisted to sessionStorage for instant chart rendering on page reload; background refresh updates silently without showing skeletons