### PR TITLE
feat: add WebAuthn/passkey login support

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -39,6 +39,10 @@ OAUTH_PRIVATE_KEY_PATH=
 OAUTH_PUBLIC_KEY=
 OAUTH_PUBLIC_KEY_PATH=
 
+# WebAuthn/Passkey settings (optional - auto-detected from request if not set)
+# WEBAUTHN_RP_ID=yourdomain.com
+# WEBAUTHN_RP_NAME=TradeTally
+
 # =============================================================================
 # APPLICATION CONFIGURATION
 # =============================================================================

--- a/backend/migrations/161_create_webauthn_credentials.sql
+++ b/backend/migrations/161_create_webauthn_credentials.sql
@@ -1,0 +1,15 @@
+-- WebAuthn/Passkey credentials for passwordless login
+CREATE TABLE IF NOT EXISTS webauthn_credentials (
+    id SERIAL PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    credential_id TEXT UNIQUE NOT NULL,
+    public_key TEXT NOT NULL,
+    counter BIGINT DEFAULT 0,
+    device_name VARCHAR(255) DEFAULT 'Unnamed passkey',
+    transports TEXT[],
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    last_used_at TIMESTAMP WITH TIME ZONE
+);
+
+CREATE INDEX IF NOT EXISTS idx_webauthn_credentials_user_id ON webauthn_credentials(user_id);
+CREATE INDEX IF NOT EXISTS idx_webauthn_credentials_credential_id ON webauthn_credentials(credential_id);

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "@opentelemetry/resources": "^2.5.0",
         "@opentelemetry/sdk-logs": "^0.211.0",
         "@parse/node-apn": "^7.0.1",
+        "@simplewebauthn/server": "^13.2.3",
         "archiver": "^7.0.1",
         "autocannon": "^8.0.0",
         "axios": "^1.13.5",
@@ -714,6 +715,12 @@
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
       }
+    },
+    "node_modules/@hexagon/base64": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
+      "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
+      "license": "MIT"
     },
     "node_modules/@img/colour": {
       "version": "1.0.0",
@@ -1687,6 +1694,12 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
       "license": "MIT"
     },
+    "node_modules/@levischuck/tiny-cbor": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
+      "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
+      "license": "MIT"
+    },
     "node_modules/@minimistjs/subarg": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@minimistjs/subarg/-/subarg-1.0.0.tgz",
@@ -1990,6 +2003,165 @@
         "node": ">= 6.13.0"
       }
     },
+    "node_modules/@peculiar/asn1-android": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.6.0.tgz",
+      "integrity": "sha512-cBRCKtYPF7vJGN76/yG8VbxRcHLPF3HnkoHhKOZeHpoVtbMYfY9ROKtH3DtYUY9m8uI1Mh47PRhHf2hSK3xcSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.6.1.tgz",
+      "integrity": "sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-x509-attr": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.6.1.tgz",
+      "integrity": "sha512-WRWnKfIocHyzFYQTka8O/tXCiBquAPSrRjXbOkHbO4qdmS6loffCEGs+rby6WxxGdJCuunnhS2duHURhjyio6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.6.1.tgz",
+      "integrity": "sha512-+Vqw8WFxrtDIN5ehUdvlN2m73exS2JVG0UAyfVB31gIfor3zWEAQPD+K9ydCxaj3MLen9k0JhKpu9LqviuCE1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.6.1.tgz",
+      "integrity": "sha512-nB5jVQy3MAAWvq0KY0R2JUZG8bO/bTLpnwyOzXyEh/e54ynGTatAR+csOnXkkVD9AFZ2uL8Z7EV918+qB1qDvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.1",
+        "@peculiar/asn1-pkcs8": "^2.6.1",
+        "@peculiar/asn1-rsa": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.6.1.tgz",
+      "integrity": "sha512-JB5iQ9Izn5yGMw3ZG4Nw3Xn/hb/G38GYF3lf7WmJb8JZUydhVGEjK/ZlFSWhnlB7K/4oqEs8HnfFIKklhR58Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.6.1.tgz",
+      "integrity": "sha512-5EV8nZoMSxeWmcxWmmcolg22ojZRgJg+Y9MX2fnE2bGRo5KQLqV5IL9kdSQDZxlHz95tHvIq9F//bvL1OeNILw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.1",
+        "@peculiar/asn1-pfx": "^2.6.1",
+        "@peculiar/asn1-pkcs8": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-x509-attr": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.6.1.tgz",
+      "integrity": "sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
+      "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.1.tgz",
+      "integrity": "sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.6.1.tgz",
+      "integrity": "sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2091,6 +2263,25 @@
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@simplewebauthn/server": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-13.2.3.tgz",
+      "integrity": "sha512-ZhcVBOw63birYx9jVfbhK6rTehckVes8PeWV324zpmdxr0BUfylospwMzcrxrdMcOi48MHWj2LCA+S528LnGvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.1",
+        "@peculiar/asn1-rsa": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/x509": "^1.14.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
@@ -2386,6 +2577,20 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
+      "integrity": "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/assert-plus": {
       "version": "1.0.0",
@@ -6941,6 +7146,24 @@
       ],
       "license": "MIT"
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/qrcode": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
@@ -7164,6 +7387,12 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/reinterval": {
       "version": "1.1.0",
@@ -8139,8 +8368,25 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
+    },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/type-detect": {
       "version": "4.0.8",

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "@opentelemetry/resources": "^2.5.0",
     "@opentelemetry/sdk-logs": "^0.211.0",
     "@parse/node-apn": "^7.0.1",
+    "@simplewebauthn/server": "^13.2.3",
     "archiver": "^7.0.1",
     "autocannon": "^8.0.0",
     "axios": "^1.13.5",

--- a/backend/src/controllers/passkey.controller.js
+++ b/backend/src/controllers/passkey.controller.js
@@ -1,0 +1,333 @@
+const db = require('../config/database');
+const challengeStore = require('../utils/webauthnChallengeStore');
+const { generateToken } = require('../middleware/auth');
+const User = require('../models/User');
+const crypto = require('crypto');
+
+// Lazy-loaded ESM imports (simplewebauthn v13 is ESM-only)
+let _webauthn = null;
+async function getWebAuthn() {
+  if (!_webauthn) {
+    _webauthn = await import('@simplewebauthn/server');
+  }
+  return _webauthn;
+}
+
+function getRpId(req) {
+  if (process.env.WEBAUTHN_RP_ID) {
+    return process.env.WEBAUTHN_RP_ID;
+  }
+  // Use the Referer header to detect the actual browser domain.
+  // The Origin header is unreliable when a dev proxy uses changeOrigin:true,
+  // but Referer is preserved and contains the real browser URL.
+  const referer = req.get('referer');
+  if (referer) {
+    try {
+      return new URL(referer).hostname;
+    } catch (e) { /* fall through */ }
+  }
+  if (process.env.FRONTEND_URL) {
+    try {
+      return new URL(process.env.FRONTEND_URL).hostname;
+    } catch (e) { /* fall through */ }
+  }
+  return req.hostname;
+}
+
+function getExpectedOrigins(req) {
+  // Return all valid origins for WebAuthn verification.
+  // The clientDataJSON.origin is set by the browser and reflects the real page origin.
+  const origins = new Set();
+
+  if (process.env.APP_URL) {
+    origins.add(process.env.APP_URL.replace(/\/$/, ''));
+  }
+  if (process.env.FRONTEND_URL) {
+    origins.add(process.env.FRONTEND_URL.replace(/\/$/, ''));
+  }
+
+  // Derive from Referer (preserved by proxies, unlike Origin with changeOrigin:true)
+  const referer = req.get('referer');
+  if (referer) {
+    try {
+      const refUrl = new URL(referer);
+      origins.add(refUrl.origin);
+    } catch (e) { /* ignore */ }
+  }
+
+  // Also include the Origin header as a fallback
+  const reqOrigin = req.get('origin');
+  if (reqOrigin) {
+    origins.add(reqOrigin.replace(/\/$/, ''));
+  }
+
+  if (origins.size === 0) {
+    const protocol = req.secure || req.headers['x-forwarded-proto'] === 'https' ? 'https' : 'http';
+    origins.add(`${protocol}://${req.get('host')}`);
+  }
+
+  return Array.from(origins);
+}
+
+function getRpName() {
+  return process.env.WEBAUTHN_RP_NAME || 'TradeTally';
+}
+
+// GET /api/auth/passkey - List user's passkeys
+async function getPasskeys(req, res, next) {
+  try {
+    const result = await db.query(
+      'SELECT id, device_name, transports, created_at, last_used_at FROM webauthn_credentials WHERE user_id = $1 ORDER BY created_at DESC',
+      [req.user.id]
+    );
+    res.json({ passkeys: result.rows });
+  } catch (error) {
+    next(error);
+  }
+}
+
+// POST /api/auth/passkey/register/options - Generate registration options
+async function registerOptions(req, res, next) {
+  try {
+    const { generateRegistrationOptions } = await getWebAuthn();
+
+    // Get existing credentials to exclude
+    const existing = await db.query(
+      'SELECT credential_id FROM webauthn_credentials WHERE user_id = $1',
+      [req.user.id]
+    );
+
+    const rpId = getRpId(req);
+    console.log('[PASSKEY] Registration rpID:', rpId, '| Referer:', req.get('referer'), '| Origin:', req.get('origin'), '| FRONTEND_URL:', process.env.FRONTEND_URL);
+
+    const options = await generateRegistrationOptions({
+      rpName: getRpName(),
+      rpID: rpId,
+      userName: req.user.email,
+      userDisplayName: req.user.full_name || req.user.username || req.user.email,
+      attestationType: 'none',
+      authenticatorSelection: {
+        residentKey: 'required',
+        userVerification: 'preferred',
+      },
+      excludeCredentials: existing.rows.map(row => ({
+        id: row.credential_id,
+        transports: row.transports || [],
+      })),
+    });
+
+    // Store challenge keyed by user ID
+    challengeStore.set(`reg:${req.user.id}`, options.challenge);
+
+    res.json(options);
+  } catch (error) {
+    next(error);
+  }
+}
+
+// POST /api/auth/passkey/register/verify - Verify and store credential
+async function registerVerify(req, res, next) {
+  try {
+    const { verifyRegistrationResponse } = await getWebAuthn();
+    const { response, deviceName } = req.body;
+
+    const expectedChallenge = challengeStore.get(`reg:${req.user.id}`);
+    if (!expectedChallenge) {
+      return res.status(400).json({ error: 'Challenge expired or not found. Please try again.' });
+    }
+
+    const verification = await verifyRegistrationResponse({
+      response,
+      expectedChallenge,
+      expectedOrigin: getExpectedOrigins(req),
+      expectedRPID: getRpId(req),
+    });
+
+    if (!verification.verified || !verification.registrationInfo) {
+      return res.status(400).json({ error: 'Passkey registration failed.' });
+    }
+
+    const { credential, credentialDeviceType, credentialBackedUp } = verification.registrationInfo;
+
+    await db.query(
+      `INSERT INTO webauthn_credentials (user_id, credential_id, public_key, counter, device_name, transports)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [
+        req.user.id,
+        credential.id,
+        Buffer.from(credential.publicKey).toString('base64url'),
+        credential.counter,
+        deviceName || 'Unnamed passkey',
+        credential.transports || [],
+      ]
+    );
+
+    challengeStore.remove(`reg:${req.user.id}`);
+
+    res.json({ verified: true });
+  } catch (error) {
+    next(error);
+  }
+}
+
+// POST /api/auth/passkey/login/options - Generate authentication options (public)
+async function loginOptions(req, res, next) {
+  try {
+    const { generateAuthenticationOptions } = await getWebAuthn();
+
+    const options = await generateAuthenticationOptions({
+      rpID: getRpId(req),
+      userVerification: 'preferred',
+      // Empty allowCredentials for discoverable credential flow
+    });
+
+    // Store challenge with a random session token
+    const sessionToken = crypto.randomBytes(32).toString('hex');
+    challengeStore.set(`auth:${sessionToken}`, options.challenge);
+
+    res.json({ ...options, sessionToken });
+  } catch (error) {
+    next(error);
+  }
+}
+
+// POST /api/auth/passkey/login/verify - Verify authentication and return JWT (public)
+async function loginVerify(req, res, next) {
+  try {
+    const { verifyAuthenticationResponse } = await getWebAuthn();
+    const { response, sessionToken } = req.body;
+
+    const expectedChallenge = challengeStore.get(`auth:${sessionToken}`);
+    if (!expectedChallenge) {
+      return res.status(400).json({ error: 'Challenge expired or not found. Please try again.' });
+    }
+
+    // Look up credential by ID
+    const credResult = await db.query(
+      'SELECT wc.*, u.id as uid, u.email, u.username, u.full_name, u.is_active, u.two_factor_enabled, u.last_login_at, u.role, u.avatar_url, u.is_verified, u.admin_approved FROM webauthn_credentials wc JOIN users u ON wc.user_id = u.id WHERE wc.credential_id = $1',
+      [response.id]
+    );
+
+    if (credResult.rows.length === 0) {
+      return res.status(400).json({ error: 'Passkey not recognized. Please use a registered passkey.' });
+    }
+
+    const cred = credResult.rows[0];
+
+    if (!cred.is_active) {
+      return res.status(403).json({ error: 'Account is disabled.' });
+    }
+
+    const verification = await verifyAuthenticationResponse({
+      response,
+      expectedChallenge,
+      expectedOrigin: getExpectedOrigins(req),
+      expectedRPID: getRpId(req),
+      credential: {
+        id: cred.credential_id,
+        publicKey: Buffer.from(cred.public_key, 'base64url'),
+        counter: Number(cred.counter),
+        transports: cred.transports || [],
+      },
+    });
+
+    if (!verification.verified) {
+      return res.status(400).json({ error: 'Passkey verification failed.' });
+    }
+
+    // Update counter and last_used_at
+    await db.query(
+      'UPDATE webauthn_credentials SET counter = $1, last_used_at = NOW() WHERE id = $2',
+      [verification.authenticationInfo.newCounter, cred.id]
+    );
+
+    challengeStore.remove(`auth:${sessionToken}`);
+
+    // Build user object for token generation and 2FA check
+    const user = {
+      id: cred.uid,
+      email: cred.email,
+      username: cred.username,
+      full_name: cred.full_name,
+      role: cred.role,
+      avatar_url: cred.avatar_url,
+      is_verified: cred.is_verified,
+      admin_approved: cred.admin_approved,
+      two_factor_enabled: cred.two_factor_enabled,
+      last_login_at: cred.last_login_at,
+    };
+
+    // Passkey authentication is inherently multi-factor (possession + biometric/PIN),
+    // so skip 2FA even if the user has it enabled on their account.
+
+    const isFirstLogin = user.last_login_at == null;
+    await User.updateLastLogin(user.id);
+
+    // Record login for Year Wrapped (best-effort)
+    try {
+      const YearWrappedService = require('../services/yearWrappedService');
+      YearWrappedService.recordLogin(user.id).catch(() => {});
+    } catch (e) { /* optional service */ }
+
+    const token = generateToken(user);
+
+    res.cookie('token', token, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 7 * 24 * 60 * 60 * 1000
+    });
+
+    // Get user tier
+    const TierService = require('../services/tierService');
+    const { tier: userTier, billingEnabled } = await TierService.getUserTierWithBillingStatus(user.id, req.headers.host);
+
+    res.json({
+      message: 'Login successful',
+      user: {
+        id: user.id,
+        email: user.email,
+        username: user.username,
+        fullName: user.full_name,
+        avatarUrl: user.avatar_url,
+        role: user.role,
+        tier: userTier,
+        billingEnabled,
+        isVerified: user.is_verified,
+        adminApproved: user.admin_approved,
+        twoFactorEnabled: user.two_factor_enabled || false,
+      },
+      is_first_login: isFirstLogin,
+      token
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+// DELETE /api/auth/passkey/:id - Delete a passkey
+async function deletePasskey(req, res, next) {
+  try {
+    const result = await db.query(
+      'DELETE FROM webauthn_credentials WHERE id = $1 AND user_id = $2 RETURNING id',
+      [req.params.id, req.user.id]
+    );
+
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'Passkey not found.' });
+    }
+
+    res.json({ message: 'Passkey deleted.' });
+  } catch (error) {
+    next(error);
+  }
+}
+
+module.exports = {
+  getPasskeys,
+  registerOptions,
+  registerVerify,
+  loginOptions,
+  loginVerify,
+  deletePasskey,
+};

--- a/backend/src/routes/passkey.routes.js
+++ b/backend/src/routes/passkey.routes.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const router = express.Router();
+const rateLimit = require('express-rate-limit');
+const passkeyController = require('../controllers/passkey.controller');
+const { authenticate } = require('../middleware/auth');
+
+// Rate limit for login endpoints
+const loginLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10,
+  message: { error: 'Too many passkey login attempts, please try again later.' },
+});
+
+// Authenticated routes - manage passkeys
+router.get('/', authenticate, passkeyController.getPasskeys);
+router.post('/register/options', authenticate, passkeyController.registerOptions);
+router.post('/register/verify', authenticate, passkeyController.registerVerify);
+router.delete('/:id', authenticate, passkeyController.deletePasskey);
+
+// Public routes - passkey login
+router.post('/login/options', loginLimiter, passkeyController.loginOptions);
+router.post('/login/verify', loginLimiter, passkeyController.loginVerify);
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -50,6 +50,7 @@ const tradeManagementRoutes = require('./routes/tradeManagement.routes');
 const aiRoutes = require('./routes/ai.routes');
 const symbolsRoutes = require('./routes/symbols.routes');
 const unsubscribeRoutes = require('./routes/unsubscribe.routes');
+const passkeyRoutes = require('./routes/passkey.routes');
 const BillingService = require('./services/billingService');
 const priceMonitoringService = require('./services/priceMonitoringService');
 const backupScheduler = require('./services/backupScheduler.service');
@@ -258,6 +259,7 @@ app.use('/api/trade-management', tradeManagementRoutes);
 app.use('/api/ai', aiRoutes);
 app.use('/api/symbols', symbolsRoutes);
 app.use('/api/unsubscribe', unsubscribeRoutes);
+app.use('/api/auth/passkey', passkeyRoutes);
 
 // OAuth2 Provider endpoints
 app.use('/oauth', oauth2Routes);

--- a/backend/src/utils/webauthnChallengeStore.js
+++ b/backend/src/utils/webauthnChallengeStore.js
@@ -1,0 +1,46 @@
+/**
+ * In-memory challenge store for WebAuthn registration/authentication flows.
+ * Challenges expire after 60 seconds. Cleanup runs every 5 minutes.
+ */
+
+const challenges = new Map();
+const TTL_MS = 60 * 1000; // 60 seconds
+const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+function set(key, challenge) {
+  challenges.set(key, {
+    challenge,
+    expires: Date.now() + TTL_MS
+  });
+}
+
+function get(key) {
+  const entry = challenges.get(key);
+  if (!entry) return null;
+  if (Date.now() > entry.expires) {
+    challenges.delete(key);
+    return null;
+  }
+  return entry.challenge;
+}
+
+function remove(key) {
+  challenges.delete(key);
+}
+
+// Periodic cleanup of expired challenges
+const cleanupTimer = setInterval(() => {
+  const now = Date.now();
+  for (const [key, entry] of challenges) {
+    if (now > entry.expires) {
+      challenges.delete(key);
+    }
+  }
+}, CLEANUP_INTERVAL_MS);
+
+// Prevent timer from keeping the process alive
+if (cleanupTimer.unref) {
+  cleanupTimer.unref();
+}
+
+module.exports = { set, get, remove };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "tradetally-frontend",
-  "version": "2.1.8",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tradetally-frontend",
-      "version": "2.1.8",
+      "version": "2.2.0",
       "dependencies": {
         "@heroicons/vue": "^2.0.18",
         "@mdi/js": "^7.4.47",
+        "@simplewebauthn/browser": "^13.2.2",
         "@stripe/stripe-js": "^2.4.0",
         "axios": "^1.13.5",
         "chart.js": "^4.5.1",
@@ -936,6 +937,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@simplewebauthn/browser": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.2.2.tgz",
+      "integrity": "sha512-FNW1oLQpTJyqG5kkDg5ZsotvWgmBaC6jCHR7Ej0qUNep36Wl9tj2eZu7J5rP+uhXgHaLk+QQ3lqcw2vS5MX1IA==",
+      "license": "MIT"
     },
     "node_modules/@stripe/stripe-js": {
       "version": "2.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@heroicons/vue": "^2.0.18",
     "@mdi/js": "^7.4.47",
+    "@simplewebauthn/browser": "^13.2.2",
     "@stripe/stripe-js": "^2.4.0",
     "axios": "^1.13.5",
     "chart.js": "^4.5.1",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -68,6 +68,35 @@
     <CookieConsentBanner v-if="isBillingEnabled" />
     <!-- Gamification celebration overlay -->
     <CelebrationOverlay :queue="celebrationQueue" />
+
+    <!-- Passkey registration prompt (shown after login if user has no passkeys) -->
+    <div v-if="showPasskeyPrompt" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+      <div class="bg-white dark:bg-gray-800 rounded-xl shadow-2xl max-w-md w-full mx-4 p-6 text-center">
+        <svg class="w-12 h-12 mx-auto mb-4 text-primary-600 dark:text-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
+        </svg>
+        <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-2">Add a passkey?</h3>
+        <p class="text-sm text-gray-600 dark:text-gray-400 mb-6">
+          Sign in faster next time using your device's biometrics, security key, or PIN. No password needed.
+        </p>
+        <div class="flex space-x-3 justify-center">
+          <button
+            @click="registerPasskey"
+            :disabled="passkeyRegistering"
+            class="px-6 py-2 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 rounded-md disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
+          >
+            <span v-if="passkeyRegistering">Setting up...</span>
+            <span v-else>Add passkey</span>
+          </button>
+          <button
+            @click="dismissPasskeyPrompt"
+            class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white"
+          >
+            Skip for now
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -90,7 +119,7 @@ import { useRegistrationMode } from '@/composables/useRegistrationMode'
 import api from '@/services/api'
 
 // Rate limit notification handling
-const { showError } = useNotification()
+const { showError, showSuccess } = useNotification()
 const lastRateLimitNotification = ref(0)
 
 const route = useRoute()
@@ -123,6 +152,63 @@ watch(() => [authStore.user?.tier, authStore.token, authStore.user?.billingEnabl
     }
   }
 }, { immediate: true })
+
+// Passkey registration prompt
+const showPasskeyPrompt = ref(false)
+const passkeyRegistering = ref(false)
+const PASSKEY_PROMPT_DISMISSED_KEY = 'passkey_prompt_dismissed'
+
+// Watch for login: when token appears, check if user has passkeys
+let previousToken = authStore.token
+watch(() => authStore.token, async (newToken) => {
+  if (newToken && !previousToken) {
+    if (localStorage.getItem(PASSKEY_PROMPT_DISMISSED_KEY)) {
+      previousToken = newToken
+      return
+    }
+    // Wait for page to settle after redirect
+    setTimeout(async () => {
+      try {
+        const res = await api.get('/auth/passkey')
+        if (!res.data.passkeys || res.data.passkeys.length === 0) {
+          showPasskeyPrompt.value = true
+        }
+      } catch (e) {
+        // Not critical
+      }
+    }, 1500)
+  }
+  previousToken = newToken
+})
+
+async function registerPasskey() {
+  passkeyRegistering.value = true
+  try {
+    const { startRegistration } = await import('@simplewebauthn/browser')
+    const optionsRes = await api.post('/auth/passkey/register/options')
+    const regResponse = await startRegistration({ optionsJSON: optionsRes.data })
+
+    await api.post('/auth/passkey/register/verify', {
+      response: regResponse,
+      deviceName: navigator.platform || 'My device',
+    })
+
+    showPasskeyPrompt.value = false
+    showSuccess('Passkey added', 'You can now sign in with your passkey next time.')
+  } catch (err) {
+    showPasskeyPrompt.value = false
+    if (err.name !== 'NotAllowedError') {
+      showError('Error', err.response?.data?.error || err.message || 'Failed to register passkey.')
+    }
+  } finally {
+    passkeyRegistering.value = false
+  }
+}
+
+function dismissPasskeyPrompt() {
+  showPasskeyPrompt.value = false
+  localStorage.setItem(PASSKEY_PROMPT_DISMISSED_KEY, 'true')
+}
 
 // Version check polling interval (6 hours)
 let versionPollInterval = null

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -42,32 +42,18 @@ export const useAuthStore = defineStore('auth', () => {
         throw twoFactorError
       }
 
-      const { user: userData, token: authToken } = response.data
+      const { token: authToken } = response.data
 
       token.value = authToken
       localStorage.setItem('token', authToken)
-
-      // Set authorization header for subsequent requests
       api.defaults.headers.common['Authorization'] = `Bearer ${authToken}`
 
       if (response.data.is_first_login === true) {
         pendingOnboarding.value = true
       }
 
-      // Fetch complete user data with settings
       await fetchUser()
-
-      // If there's a return URL, redirect there instead of dashboard
-      if (returnUrl) {
-        const decoded = decodeURIComponent(returnUrl)
-        if (decoded.startsWith('/')) {
-          router.push(decoded)
-        } else {
-          window.location.href = decoded
-        }
-      } else {
-        router.push({ name: 'dashboard' })
-      }
+      navigateAfterLogin(returnUrl)
 
       return response.data
     } catch (err) {
@@ -78,6 +64,19 @@ export const useAuthStore = defineStore('auth', () => {
       throw err
     } finally {
       loading.value = false
+    }
+  }
+
+  function navigateAfterLogin(returnUrl = null) {
+    if (returnUrl) {
+      const decoded = decodeURIComponent(returnUrl)
+      if (decoded.startsWith('/')) {
+        router.push(decoded)
+      } else {
+        window.location.href = decoded
+      }
+    } else {
+      router.push({ name: 'dashboard' })
     }
   }
 
@@ -241,6 +240,63 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
+  async function loginWithPasskey(returnUrl = null) {
+    loading.value = true
+    error.value = null
+
+    try {
+      const { startAuthentication } = await import('@simplewebauthn/browser')
+
+      // Get authentication options from server
+      const optionsRes = await api.post('/auth/passkey/login/options')
+      const options = optionsRes.data
+      const sessionToken = options.sessionToken
+
+      // Prompt user's browser/device for passkey
+      const authResponse = await startAuthentication({ optionsJSON: options })
+
+      // Verify with server
+      const verifyRes = await api.post('/auth/passkey/login/verify', {
+        response: authResponse,
+        sessionToken
+      })
+
+      // Check if 2FA is required
+      if (verifyRes.data.requires2FA) {
+        const twoFactorError = new Error('Two-factor authentication required')
+        twoFactorError.requires2FA = true
+        twoFactorError.tempToken = verifyRes.data.tempToken
+        throw twoFactorError
+      }
+
+      const { token: authToken } = verifyRes.data
+
+      token.value = authToken
+      localStorage.setItem('token', authToken)
+      api.defaults.headers.common['Authorization'] = `Bearer ${authToken}`
+
+      if (verifyRes.data.is_first_login === true) {
+        pendingOnboarding.value = true
+      }
+
+      await fetchUser()
+      navigateAfterLogin(returnUrl)
+
+      return verifyRes.data
+    } catch (err) {
+      if (!err.requires2FA) {
+        if (err.name === 'NotAllowedError') {
+          error.value = 'No passkey found for this device, or the request was cancelled. Register a passkey from your Profile first.'
+        } else {
+          error.value = err.response?.data?.error || err.message || 'Passkey login failed'
+        }
+      }
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
   async function completeOnboarding() {
     try {
       await api.post('/users/onboarding-completed')
@@ -288,6 +344,8 @@ export const useAuthStore = defineStore('auth', () => {
     forgotPassword,
     resetPassword,
     verify2FA,
+    loginWithPasskey,
+    navigateAfterLogin,
     completeOnboarding,
     getRegistrationConfig
   }

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -256,6 +256,69 @@
                 </div>
             </div>
 
+            <!-- Passkeys -->
+            <div class="card">
+                <div class="card-body">
+                    <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-6">
+                        Passkeys
+                    </h3>
+                    <p class="text-sm text-gray-600 dark:text-gray-400 mb-6">
+                        Sign in without a password using your device's biometrics, security key, or PIN.
+                    </p>
+
+                    <!-- Loading -->
+                    <div v-if="passkeysLoading && passkeys.length === 0" class="flex justify-center py-4">
+                        <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
+                    </div>
+
+                    <!-- Passkey list -->
+                    <div v-if="passkeys.length > 0" class="space-y-3 mb-6">
+                        <div
+                            v-for="pk in passkeys"
+                            :key="pk.id"
+                            class="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800 rounded-lg"
+                        >
+                            <div class="flex items-center space-x-3">
+                                <svg class="w-5 h-5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
+                                </svg>
+                                <div>
+                                    <p class="text-sm font-medium text-gray-900 dark:text-white">
+                                        {{ pk.device_name }}
+                                    </p>
+                                    <p class="text-xs text-gray-500 dark:text-gray-400">
+                                        Added {{ formatDate(pk.created_at) }}
+                                        <span v-if="pk.last_used_at"> - Last used {{ formatDate(pk.last_used_at) }}</span>
+                                    </p>
+                                </div>
+                            </div>
+                            <button
+                                @click="deletePasskeyConfirm(pk)"
+                                class="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 text-sm"
+                            >
+                                Delete
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- No passkeys message -->
+                    <div v-else-if="!passkeysLoading" class="mb-6">
+                        <p class="text-sm text-gray-500 dark:text-gray-400">
+                            No passkeys registered yet.
+                        </p>
+                    </div>
+
+                    <button
+                        @click="addPasskey"
+                        :disabled="addingPasskey"
+                        class="btn-primary"
+                    >
+                        <span v-if="addingPasskey">Registering...</span>
+                        <span v-else>Add passkey</span>
+                    </button>
+                </div>
+            </div>
+
             <!-- Subscription Status -->
             <div v-if="billingStatus.billing_available" class="card">
                 <div class="card-body">
@@ -1518,6 +1581,12 @@ const subscription = ref({
     has_used_trial: false,
 });
 
+// Passkeys data
+const passkeys = ref([]);
+const passkeysLoading = ref(false);
+const addingPasskey = ref(false);
+const passkeyToDelete = ref(null);
+
 // API Keys data
 const apiKeys = ref([]);
 const apiKeysLoading = ref(false);
@@ -1796,6 +1865,77 @@ function cancel2FASetup() {
     qrCodeUrl.value = "";
     setupSecret.value = "";
     backupCodes.value = [];
+}
+
+// Passkey methods
+async function fetchPasskeys() {
+    try {
+        passkeysLoading.value = true;
+        const response = await api.get("/auth/passkey");
+        passkeys.value = response.data.passkeys;
+    } catch (error) {
+        console.error("[PASSKEYS] Failed to fetch passkeys:", error);
+    } finally {
+        passkeysLoading.value = false;
+    }
+}
+
+async function addPasskey() {
+    console.log("[PASSKEY] addPasskey() called");
+    addingPasskey.value = true;
+    try {
+        console.log("[PASSKEY] Importing @simplewebauthn/browser...");
+        const { startRegistration } = await import("@simplewebauthn/browser");
+        console.log("[PASSKEY] Import OK, fetching options...");
+
+        // Get registration options
+        const optionsRes = await api.post("/auth/passkey/register/options");
+        const options = optionsRes.data;
+        console.log("[PASSKEY] Options received, rpID:", options.rp?.id, "options:", JSON.stringify(options).substring(0, 200));
+
+        // Prompt browser for passkey creation
+        const regResponse = await startRegistration({ optionsJSON: options });
+        console.log("[PASSKEY] Registration response received");
+
+        // Ask for device name
+        const deviceName = prompt("Name this passkey (e.g., MacBook Touch ID):") || "Unnamed passkey";
+
+        // Verify with server
+        await api.post("/auth/passkey/register/verify", {
+            response: regResponse,
+            deviceName,
+        });
+
+        showSuccess("Success", "Passkey registered successfully.");
+        await fetchPasskeys();
+    } catch (error) {
+        console.error("[PASSKEY] Registration error:", error.name, error.message, error);
+        if (error.name === "NotAllowedError" || error.name === "InvalidStateError") {
+            showError("Cancelled", "Passkey registration was cancelled.");
+        } else {
+            showError("Error", error.response?.data?.error || error.message || "Failed to register passkey.");
+        }
+    } finally {
+        addingPasskey.value = false;
+    }
+}
+
+function deletePasskeyConfirm(pk) {
+    passkeyToDelete.value = pk;
+    if (confirm(`Delete passkey "${pk.device_name}"? This cannot be undone.`)) {
+        deletePasskey(pk.id);
+    }
+    passkeyToDelete.value = null;
+}
+
+async function deletePasskey(id) {
+    try {
+        await api.delete(`/auth/passkey/${id}`);
+        showSuccess("Success", "Passkey deleted.");
+        await fetchPasskeys();
+    } catch (error) {
+        showError("Error", error.response?.data?.error || "Failed to delete passkey.");
+    }
 }
 
 // API Key methods
@@ -2079,6 +2219,7 @@ onMounted(async () => {
     // Load all data
     await Promise.all([
         fetch2FAStatus(),
+        fetchPasskeys(),
         fetchApiKeys(),
         fetchTradingProfile(),
         loadBillingStatus(),

--- a/frontend/src/views/auth/LoginView.vue
+++ b/frontend/src/views/auth/LoginView.vue
@@ -31,7 +31,7 @@
           @cancel="handleTwoFactorCancel"
         />
       </div>
-      
+
       <form v-else class="mt-8 space-y-6" @submit.prevent="handleLogin">
         <div class="rounded-md shadow-sm -space-y-px">
           <div>
@@ -81,7 +81,7 @@
             </p>
           </div>
         </div>
-        
+
         <!-- Resend verification success message -->
         <div v-if="resendSuccess" class="rounded-md bg-green-50 dark:bg-green-900/20 p-4">
           <p class="text-sm text-green-800 dark:text-green-400">
@@ -97,6 +97,32 @@
           >
             <span v-if="authStore.loading">Signing in...</span>
             <span v-else>Sign in</span>
+          </button>
+        </div>
+
+        <!-- Divider -->
+        <div class="relative">
+          <div class="absolute inset-0 flex items-center">
+            <div class="w-full border-t border-gray-300 dark:border-gray-600"></div>
+          </div>
+          <div class="relative flex justify-center text-sm">
+            <span class="px-2 bg-gray-50 dark:bg-gray-900 text-gray-500 dark:text-gray-400">or</span>
+          </div>
+        </div>
+
+        <!-- Passkey login -->
+        <div>
+          <button
+            type="button"
+            :disabled="passkeyLoading"
+            @click="handlePasskeyLogin"
+            class="group relative w-full flex justify-center py-2 px-4 border border-gray-300 dark:border-gray-600 text-sm font-medium rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:opacity-50"
+          >
+            <svg class="w-5 h-5 mr-2 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
+            </svg>
+            <span v-if="passkeyLoading">Verifying passkey...</span>
+            <span v-else>Sign in with passkey</span>
           </button>
         </div>
 
@@ -133,6 +159,7 @@ const resendCooldown = ref(0)
 const resendSuccess = ref(false)
 const showTwoFactor = ref(false)
 const tempToken = ref('')
+const passkeyLoading = ref(false)
 
 const form = ref({
   email: '',
@@ -140,7 +167,6 @@ const form = ref({
 })
 
 async function handleLogin() {
-  // Reset state
   showResendVerification.value = false
   showApprovalMessage.value = false
   resendSuccess.value = false
@@ -149,7 +175,6 @@ async function handleLogin() {
   tempToken.value = ''
 
   try {
-    // Check if there's a return URL from OAuth flow or a redirect path
     const returnUrl = route.query.return_url || route.query.redirect || null
     await authStore.login(form.value, returnUrl)
   } catch (error) {
@@ -159,10 +184,30 @@ async function handleLogin() {
     } else if (error.requires2FA) {
       showTwoFactor.value = true
       tempToken.value = error.tempToken
-      // Clear any error message since 2FA is a normal flow
       authStore.error = null
     }
-    // Error will be displayed via authStore.error in the template
+  }
+}
+
+async function handlePasskeyLogin() {
+  passkeyLoading.value = true
+  showResendVerification.value = false
+  showApprovalMessage.value = false
+  resendSuccess.value = false
+  showTwoFactor.value = false
+  authStore.error = null
+
+  try {
+    const returnUrl = route.query.return_url || route.query.redirect || null
+    await authStore.loginWithPasskey(returnUrl)
+  } catch (error) {
+    if (error.requires2FA) {
+      showTwoFactor.value = true
+      tempToken.value = error.tempToken
+      authStore.error = null
+    }
+  } finally {
+    passkeyLoading.value = false
   }
 }
 
@@ -172,22 +217,19 @@ async function handleResendVerification() {
     showError('Error', 'Please enter your email address')
     return
   }
-  
+
   resendLoading.value = true
   resendSuccess.value = false
-  
+
   try {
     const response = await api.post('/auth/resend-verification', {
       email: emailToUse
     })
-    
+
     resendSuccess.value = true
     showSuccess('Success', response.data.message)
-    
-    // Clear the auth error since we've sent a new verification email
     authStore.error = null
-    
-    // Start cooldown timer
+
     resendCooldown.value = 60
     const cooldownInterval = setInterval(() => {
       resendCooldown.value--
@@ -195,7 +237,7 @@ async function handleResendVerification() {
         clearInterval(cooldownInterval)
       }
     }, 1000)
-    
+
   } catch (error) {
     showError('Error', error.response?.data?.error || 'Failed to resend verification email')
   } finally {
@@ -218,10 +260,8 @@ function handleTwoFactorCancel() {
 }
 
 onMounted(async () => {
-  // Fetch registration config to determine if registration is allowed
   await fetchRegistrationConfig()
-  
-  // Check for verification message from registration
+
   if (route.query.message) {
     verificationMessage.value = route.query.message
   }


### PR DESCRIPTION
Add passwordless authentication via passkeys (WebAuthn discoverable credentials). Users register passkeys from their profile or via a post-login prompt, then sign in with biometrics/PIN without needing a password or 2FA code.

- New webauthn_credentials table with UUID FK to users
- Backend controller with registration and authentication flows
- Challenge store with 60s TTL for WebAuthn ceremonies
- RP ID/origin auto-detected from Referer and FRONTEND_URL
- Post-login modal in App.vue prompts passkey setup (dismissible)
- Login page "Sign in with passkey" button for returning users
- Profile page passkey management (list, add, delete)
- Passkey login bypasses 2FA (passkey is inherently multi-factor)