### PR TITLE
feat: modernize admin analytics with auto-refresh and consolidated cards

### DIFF
--- a/frontend/src/views/admin/AdminAnalyticsView.vue
+++ b/frontend/src/views/admin/AdminAnalyticsView.vue
@@ -7,26 +7,38 @@
                     Monitor user activity, imports, and API usage
                 </p>
             </div>
-            <div
-                v-if="activeConnections !== null"
-                class="flex items-center space-x-2 bg-white dark:bg-gray-800 rounded-lg shadow px-4 py-3 border border-gray-200 dark:border-gray-700"
-            >
-                <span class="relative flex h-3 w-3">
-                    <span
-                        class="animate-ping absolute inline-flex h-full w-full rounded-full opacity-75"
-                        :class="activeConnections > 0 ? 'bg-green-400' : 'bg-gray-400'"
-                    ></span>
-                    <span
-                        class="relative inline-flex rounded-full h-3 w-3"
-                        :class="activeConnections > 0 ? 'bg-green-500' : 'bg-gray-400'"
-                    ></span>
-                </span>
-                <div class="text-right">
+            <div class="flex items-center gap-3">
+                <!-- Auto-refresh indicator -->
+                <div v-if="!initialLoading && analytics" class="flex items-center gap-2 text-xs text-gray-400 dark:text-gray-500">
+                    <button
+                        @click="fetchAnalytics"
+                        :disabled="loading"
+                        class="hover:text-gray-600 dark:hover:text-gray-300 transition-colors disabled:opacity-50"
+                        title="Refresh now"
+                    >
+                        <svg class="w-3.5 h-3.5" :class="{ 'animate-spin': loading }" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                        </svg>
+                    </button>
+                    <span v-if="lastUpdated">{{ lastUpdatedText }}</span>
+                </div>
+                <!-- Active connections -->
+                <div
+                    v-if="activeConnections !== null"
+                    class="flex items-center space-x-2 bg-white dark:bg-gray-800 rounded-lg shadow-sm px-3 py-2 border border-gray-200 dark:border-gray-700"
+                >
+                    <span class="relative flex h-2.5 w-2.5">
+                        <span
+                            class="animate-ping absolute inline-flex h-full w-full rounded-full opacity-75"
+                            :class="activeConnections > 0 ? 'bg-green-400' : 'bg-gray-400'"
+                        ></span>
+                        <span
+                            class="relative inline-flex rounded-full h-2.5 w-2.5"
+                            :class="activeConnections > 0 ? 'bg-green-500' : 'bg-gray-400'"
+                        ></span>
+                    </span>
                     <p class="text-lg font-semibold text-gray-900 dark:text-white leading-tight">
                         {{ activeConnections }}
-                    </p>
-                    <p class="text-xs text-gray-500 dark:text-gray-400">
-                        Connected now
                     </p>
                 </div>
             </div>
@@ -53,8 +65,8 @@
             </div>
         </div>
 
-        <!-- Loading state -->
-        <div v-if="loading" class="flex justify-center items-center h-64">
+        <!-- Full-page spinner only on initial load -->
+        <div v-if="initialLoading" class="flex justify-center items-center h-64">
             <div
                 class="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600"
             ></div>
@@ -77,357 +89,129 @@
         </div>
 
         <template v-else-if="analytics">
-            <!-- Summary Cards: stacked layout so they align at any viewport size -->
-            <div
-                class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4 mb-8"
-            >
-                <div
-                    class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 sm:p-5 min-h-[7.5rem] flex flex-col"
-                >
-                    <div
-                        class="flex-shrink-0 w-10 h-10 flex items-center justify-center rounded-lg bg-primary-100 dark:bg-primary-900/30"
-                    >
-                        <svg
-                            class="h-5 w-5 text-primary-600 dark:text-primary-400"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                        >
-                            <path
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="2"
-                                d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
-                            />
-                        </svg>
-                    </div>
-                    <div class="mt-3 min-w-0 flex-1">
-                        <p
-                            class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate"
-                        >
-                            Total Users
-                        </p>
-                        <p
-                            class="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-white truncate"
-                            :title="formatNumber(analytics.summary.totalUsers)"
-                        >
-                            {{ formatNumber(analytics.summary.totalUsers) }}
-                        </p>
-                    </div>
-                </div>
-
-                <div
-                    class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 sm:p-5 min-h-[7.5rem] flex flex-col"
-                >
-                    <div
-                        class="flex-shrink-0 w-10 h-10 flex items-center justify-center rounded-lg bg-green-100 dark:bg-green-900/30"
-                    >
-                        <svg
-                            class="h-5 w-5 text-green-600 dark:text-green-400"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                        >
-                            <path
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="2"
-                                d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"
-                            />
-                        </svg>
-                    </div>
-                    <div class="mt-3 min-w-0 flex-1">
-                        <p
-                            class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate"
-                        >
-                            New Signups
-                        </p>
-                        <p
-                            class="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-white truncate"
-                            :title="formatNumber(analytics.summary.newSignups)"
-                        >
-                            {{ formatNumber(analytics.summary.newSignups) }}
-                        </p>
-                    </div>
-                </div>
-
-                <div
-                    class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 sm:p-5 min-h-[7.5rem] flex flex-col"
-                >
-                    <div
-                        class="flex-shrink-0 w-10 h-10 flex items-center justify-center rounded-lg bg-purple-100 dark:bg-purple-900/30"
-                    >
-                        <svg
-                            class="h-5 w-5 text-purple-600 dark:text-purple-400"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                        >
-                            <path
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="2"
-                                d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-                            />
-                        </svg>
-                    </div>
-                    <div class="mt-3 min-w-0 flex-1">
-                        <p
-                            class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate"
-                        >
-                            Active Today
-                        </p>
-                        <p
-                            class="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-white truncate"
-                            :title="formatNumber(analytics.summary.activeToday)"
-                        >
-                            {{ formatNumber(analytics.summary.activeToday) }}
-                        </p>
-                    </div>
-                </div>
-
-                <div
-                    class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 sm:p-5 min-h-[7.5rem] flex flex-col"
-                >
-                    <div
-                        class="flex-shrink-0 w-10 h-10 flex items-center justify-center rounded-lg bg-orange-100 dark:bg-orange-900/30"
-                    >
-                        <svg
-                            class="h-5 w-5 text-orange-600 dark:text-orange-400"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                        >
-                            <path
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="2"
-                                d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
-                            />
-                        </svg>
-                    </div>
-                    <div class="mt-3 min-w-0 flex-1">
-                        <p
-                            class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate"
-                        >
-                            Trades Imported
-                        </p>
-                        <p
-                            class="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-white truncate"
-                            :title="
-                                formatNumber(analytics.summary.tradesImported)
-                            "
-                        >
-                            {{ formatNumber(analytics.summary.tradesImported) }}
-                        </p>
-                    </div>
-                </div>
-
-                <div
-                    class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 sm:p-5 min-h-[7.5rem] flex flex-col"
-                >
-                    <div
-                        class="flex-shrink-0 w-10 h-10 flex items-center justify-center rounded-lg bg-red-100 dark:bg-red-900/30"
-                    >
-                        <svg
-                            class="h-5 w-5 text-red-600 dark:text-red-400"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                        >
-                            <path
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="2"
-                                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                            />
-                        </svg>
-                    </div>
-                    <div class="mt-3 min-w-0 flex-1">
-                        <p
-                            class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate"
-                        >
-                            Account Deletions
-                        </p>
-                        <p
-                            class="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-white truncate"
-                            :title="
-                                formatNumber(
-                                    analytics.summary.accountDeletions || 0,
-                                )
-                            "
-                        >
-                            {{
-                                formatNumber(
-                                    analytics.summary.accountDeletions || 0,
-                                )
-                            }}
-                        </p>
-                        <p
-                            class="text-xs text-gray-400 dark:text-gray-500 mt-0.5 truncate"
-                        >
-                            {{
-                                formatNumber(
-                                    analytics.summary.selfDeletions || 0,
-                                )
-                            }}
-                            self,
-                            {{
-                                formatNumber(
-                                    analytics.summary.adminDeletions || 0,
-                                )
-                            }}
-                            admin
-                        </p>
-                    </div>
+            <!-- Refresh overlay indicator -->
+            <div v-if="loading" class="fixed top-4 right-4 z-50">
+                <div class="flex items-center space-x-2 bg-white/90 dark:bg-gray-800/90 backdrop-blur-sm px-3 py-1.5 rounded-full shadow-sm border border-gray-200 dark:border-gray-700">
+                    <div class="animate-spin rounded-full h-3.5 w-3.5 border-2 border-primary-600 border-t-transparent"></div>
+                    <span class="text-xs text-gray-600 dark:text-gray-400">Updating...</span>
                 </div>
             </div>
 
-            <!-- Revenue / Subscriptions Section -->
+            <!-- Summary Cards -->
+            <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mb-8">
+                <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700/50 p-5">
+                    <p class="text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500">Total Users</p>
+                    <p class="text-2xl font-bold text-gray-900 dark:text-white mt-1.5">
+                        {{ formatNumber(analytics.summary.totalUsers) }}
+                    </p>
+                </div>
+
+                <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700/50 p-5">
+                    <p class="text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500">New Signups</p>
+                    <p class="text-2xl font-bold text-gray-900 dark:text-white mt-1.5">
+                        {{ formatNumber(analytics.summary.newSignups) }}
+                    </p>
+                </div>
+
+                <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700/50 p-5">
+                    <p class="text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500">Active Today</p>
+                    <p class="text-2xl font-bold text-gray-900 dark:text-white mt-1.5">
+                        {{ formatNumber(analytics.summary.activeToday) }}
+                    </p>
+                </div>
+
+                <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700/50 p-5">
+                    <p class="text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500">Trades Imported</p>
+                    <p class="text-2xl font-bold text-gray-900 dark:text-white mt-1.5">
+                        {{ formatNumber(analytics.summary.tradesImported) }}
+                    </p>
+                </div>
+
+                <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700/50 p-5">
+                    <p class="text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500">Account Deletions</p>
+                    <p class="text-2xl font-bold text-gray-900 dark:text-white mt-1.5">
+                        {{ formatNumber(analytics.summary.accountDeletions || 0) }}
+                    </p>
+                    <p class="text-xs text-gray-400 dark:text-gray-500 mt-0.5">
+                        {{ formatNumber(analytics.summary.selfDeletions || 0) }} self,
+                        {{ formatNumber(analytics.summary.adminDeletions || 0) }} admin
+                    </p>
+                </div>
+            </div>
+
+            <!-- Revenue & Subscriptions Section -->
             <div v-if="analytics.subscriptionMetrics" class="mb-8">
-                <h2
-                    class="text-lg font-semibold text-gray-900 dark:text-white mb-4"
-                >
+                <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">
                     Revenue & Subscriptions
                 </h2>
-                <div
-                    class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"
-                >
-                    <div
-                        class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 sm:p-5 min-h-[7.5rem] flex flex-col justify-center min-w-0"
-                    >
-                        <p
-                            class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate"
-                        >
-                            Paying Users
+                <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                    <!-- Combined: Revenue + Paying Users -->
+                    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700/50 p-5">
+                        <p class="text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500">Monthly Revenue</p>
+                        <p class="text-2xl font-bold text-gray-900 dark:text-white mt-1.5">
+                            ${{ formatCurrency(analytics.subscriptionMetrics.mrr) }}
                         </p>
-                        <p
-                            class="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-white truncate mt-1"
-                            :title="
-                                formatNumber(
-                                    analytics.subscriptionMetrics.payingUsers,
-                                )
-                            "
-                        >
-                            {{
-                                formatNumber(
-                                    analytics.subscriptionMetrics.payingUsers,
-                                )
-                            }}
+                        <div class="flex items-center gap-1.5 mt-2">
+                            <span class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-primary-50 dark:bg-primary-900/30">
+                                <svg class="w-3 h-3 text-primary-600 dark:text-primary-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                                </svg>
+                            </span>
+                            <span class="text-sm text-gray-500 dark:text-gray-400">
+                                {{ formatNumber(analytics.subscriptionMetrics.payingUsers) }} paying users
+                            </span>
+                        </div>
+                    </div>
+
+                    <!-- Combined: Conversion Funnel -->
+                    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700/50 p-5">
+                        <p class="text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500">Conversion Funnel</p>
+                        <div class="mt-2.5 space-y-2">
+                            <!-- Trial start rate -->
+                            <div class="flex items-center justify-between">
+                                <span class="text-sm text-gray-600 dark:text-gray-300">Signups to Trial</span>
+                                <span class="text-sm font-semibold text-gray-900 dark:text-white">{{ analytics.subscriptionMetrics.trialStartRate }}%</span>
+                            </div>
+                            <div class="w-full bg-gray-100 dark:bg-gray-700 rounded-full h-1.5">
+                                <div
+                                    class="bg-primary-500 h-1.5 rounded-full transition-all duration-500"
+                                    :style="{ width: Math.min(analytics.subscriptionMetrics.trialStartRate, 100) + '%' }"
+                                ></div>
+                            </div>
+                            <!-- Trial to paid -->
+                            <div class="flex items-center justify-between mt-1">
+                                <span class="text-sm text-gray-600 dark:text-gray-300">Trial to Paid</span>
+                                <span class="text-sm font-semibold text-gray-900 dark:text-white">{{ analytics.subscriptionMetrics.trialConversionRate }}%</span>
+                            </div>
+                            <div class="w-full bg-gray-100 dark:bg-gray-700 rounded-full h-1.5">
+                                <div
+                                    class="bg-green-500 h-1.5 rounded-full transition-all duration-500"
+                                    :style="{ width: Math.min(analytics.subscriptionMetrics.trialConversionRate, 100) + '%' }"
+                                ></div>
+                            </div>
+                        </div>
+                        <p class="text-xs text-gray-400 dark:text-gray-500 mt-2">
+                            {{ analytics.subscriptionMetrics.trialsStartedInPeriod }} trials / {{ analytics.subscriptionMetrics.signupsInPeriod }} signups
+                            &middot;
+                            {{ analytics.subscriptionMetrics.trialConvertedCount }} / {{ analytics.subscriptionMetrics.totalTrialUsers }} converted
                         </p>
                     </div>
-                    <div
-                        class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 sm:p-5 min-h-[7.5rem] flex flex-col justify-center min-w-0"
-                    >
-                        <p
-                            class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate"
-                        >
-                            MRR
-                        </p>
-                        <p
-                            class="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-white truncate mt-1"
-                            :title="
-                                '$' +
-                                formatCurrency(
-                                    analytics.subscriptionMetrics.mrr,
-                                )
-                            "
-                        >
-                            ${{
-                                formatCurrency(
-                                    analytics.subscriptionMetrics.mrr,
-                                )
-                            }}
+
+                    <!-- At-Risk -->
+                    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700/50 p-5">
+                        <p class="text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500">At-Risk (Canceling)</p>
+                        <p class="text-2xl font-bold text-gray-900 dark:text-white mt-1.5">
+                            {{ formatNumber(analytics.subscriptionMetrics.atRiskCancellations) }}
                         </p>
                     </div>
+
+                    <!-- Expired (clickable) -->
                     <div
-                        class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 sm:p-5 min-h-[7.5rem] flex flex-col justify-center min-w-0"
-                    >
-                        <p
-                            class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate"
-                        >
-                            Trial Start Rate
-                        </p>
-                        <p
-                            class="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-white mt-1"
-                        >
-                            {{ analytics.subscriptionMetrics.trialStartRate }}%
-                        </p>
-                        <p
-                            class="text-xs text-gray-400 dark:text-gray-500 mt-0.5 truncate"
-                        >
-                            {{
-                                analytics.subscriptionMetrics
-                                    .trialsStartedInPeriod
-                            }}
-                            trials /
-                            {{ analytics.subscriptionMetrics.signupsInPeriod }}
-                            signups
-                        </p>
-                    </div>
-                    <div
-                        class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 sm:p-5 min-h-[7.5rem] flex flex-col justify-center min-w-0"
-                    >
-                        <p
-                            class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate"
-                        >
-                            Trial to Paid
-                        </p>
-                        <p
-                            class="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-white mt-1"
-                        >
-                            {{
-                                analytics.subscriptionMetrics
-                                    .trialConversionRate
-                            }}%
-                        </p>
-                        <p
-                            class="text-xs text-gray-400 dark:text-gray-500 mt-0.5 truncate"
-                        >
-                            {{
-                                analytics.subscriptionMetrics
-                                    .trialConvertedCount
-                            }}
-                            /
-                            {{ analytics.subscriptionMetrics.totalTrialUsers }}
-                            trial users
-                        </p>
-                    </div>
-                    <div
-                        class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 sm:p-5 min-h-[7.5rem] flex flex-col justify-center min-w-0"
-                    >
-                        <p
-                            class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate"
-                        >
-                            At-Risk (Canceling)
-                        </p>
-                        <p
-                            class="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-white truncate mt-1"
-                            :title="
-                                formatNumber(
-                                    analytics.subscriptionMetrics
-                                        .atRiskCancellations,
-                                )
-                            "
-                        >
-                            {{
-                                formatNumber(
-                                    analytics.subscriptionMetrics
-                                        .atRiskCancellations,
-                                )
-                            }}
-                        </p>
-                    </div>
-                    <div
-                        class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 sm:p-5 min-h-[7.5rem] flex flex-col justify-center min-w-0 cursor-pointer ring-1 ring-transparent hover:ring-primary-300 dark:hover:ring-primary-700 transition-all"
+                        class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700/50 p-5 cursor-pointer hover:border-primary-300 dark:hover:border-primary-700 transition-colors"
                         @click="showExpiredTrialUsers = !showExpiredTrialUsers"
                     >
                         <div class="flex items-center justify-between">
-                            <p
-                                class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate"
-                            >
-                                Expired (Not Converted)
-                            </p>
+                            <p class="text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500">Expired (Not Converted)</p>
                             <svg
                                 class="w-4 h-4 text-gray-400 transition-transform"
                                 :class="{ 'rotate-180': showExpiredTrialUsers }"
@@ -436,49 +220,21 @@
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
                             </svg>
                         </div>
-                        <p
-                            class="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-white truncate mt-1"
-                            :title="
-                                formatNumber(
-                                    analytics.subscriptionMetrics
-                                        .expiredTrialNotConverted,
-                                )
-                            "
-                        >
-                            {{
-                                formatNumber(
-                                    analytics.subscriptionMetrics
-                                        .expiredTrialNotConverted,
-                                )
-                            }}
+                        <p class="text-2xl font-bold text-gray-900 dark:text-white mt-1.5">
+                            {{ formatNumber(analytics.subscriptionMetrics.expiredTrialNotConverted) }}
                         </p>
-                        <p
-                            class="text-xs text-gray-400 dark:text-gray-500 mt-0.5 truncate"
-                        >
+                        <p class="text-xs text-gray-400 dark:text-gray-500 mt-0.5">
                             trial ended, no subscription
                         </p>
                     </div>
-                    <div
-                        class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 sm:p-5 min-h-[7.5rem] flex flex-col justify-center min-w-0"
-                    >
-                        <p
-                            class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate"
-                        >
-                            Conversion Emails Sent
+
+                    <!-- Conversion Emails Sent -->
+                    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700/50 p-5">
+                        <p class="text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500">Conversion Emails Sent</p>
+                        <p class="text-2xl font-bold text-gray-900 dark:text-white mt-1.5">
+                            {{ formatNumber(analytics.subscriptionMetrics.conversionEmailsSent) }}
                         </p>
-                        <p
-                            class="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-white truncate mt-1"
-                        >
-                            {{
-                                formatNumber(
-                                    analytics.subscriptionMetrics
-                                        .conversionEmailsSent,
-                                )
-                            }}
-                        </p>
-                        <p
-                            class="text-xs text-gray-400 dark:text-gray-500 mt-0.5 truncate"
-                        >
+                        <p class="text-xs text-gray-400 dark:text-gray-500 mt-0.5">
                             {{ formatNumber(analytics.subscriptionMetrics.convertedAfterEmail) }} converted
                             <template v-if="analytics.subscriptionMetrics.conversionEmailsPending > 0">
                                 &middot; {{ formatNumber(analytics.subscriptionMetrics.conversionEmailsPending) }} pending
@@ -490,7 +246,7 @@
                 <!-- Expired Trial Users Detail -->
                 <div
                     v-if="showExpiredTrialUsers && analytics.subscriptionMetrics.expiredTrialUsers?.length"
-                    class="mt-4 bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden"
+                    class="mt-4 bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700/50 overflow-hidden"
                 >
                     <div class="px-4 py-3 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
                         <h3 class="text-sm font-medium text-gray-900 dark:text-white">
@@ -539,168 +295,77 @@
 
             <!-- Activation Section -->
             <div v-if="analytics.activation" class="mb-8">
-                <h2
-                    class="text-lg font-semibold text-gray-900 dark:text-white mb-4"
-                >
+                <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">
                     Activation
                 </h2>
-                <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                    <div
-                        class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 sm:p-5 min-h-[7.5rem] flex flex-col justify-center min-w-0"
-                    >
-                        <p
-                            class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate"
-                        >
-                            Activation Rate
-                        </p>
-                        <p
-                            class="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-white mt-1"
-                        >
+                <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700/50 p-5">
+                        <p class="text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500">Activation Rate</p>
+                        <p class="text-2xl font-bold text-gray-900 dark:text-white mt-1.5">
                             {{ analytics.activation.activationRatePercent }}%
                         </p>
-                        <p
-                            class="text-xs text-gray-400 dark:text-gray-500 mt-0.5 truncate"
-                        >
+                        <p class="text-xs text-gray-400 dark:text-gray-500 mt-0.5">
                             Import within 7 days of signup
                         </p>
                     </div>
-                    <div
-                        class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 sm:p-5 min-h-[7.5rem] flex flex-col justify-center min-w-0"
-                    >
-                        <p
-                            class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate"
-                        >
-                            Activated
-                        </p>
-                        <p
-                            class="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-white truncate mt-1"
-                            :title="
-                                formatNumber(
-                                    analytics.activation.activatedCount,
-                                )
-                            "
-                        >
-                            {{
-                                formatNumber(
-                                    analytics.activation.activatedCount,
-                                )
-                            }}
+                    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700/50 p-5">
+                        <p class="text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500">Activated</p>
+                        <p class="text-2xl font-bold text-gray-900 dark:text-white mt-1.5">
+                            {{ formatNumber(analytics.activation.activatedCount) }}
                         </p>
                     </div>
-                    <div
-                        class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 sm:p-5 min-h-[7.5rem] flex flex-col justify-center min-w-0"
-                    >
-                        <p
-                            class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate"
-                        >
-                            Signups (period)
-                        </p>
-                        <p
-                            class="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-white truncate mt-1"
-                            :title="
-                                formatNumber(analytics.activation.signupsCount)
-                            "
-                        >
-                            {{
-                                formatNumber(analytics.activation.signupsCount)
-                            }}
+                    <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700/50 p-5">
+                        <p class="text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500">Signups (period)</p>
+                        <p class="text-2xl font-bold text-gray-900 dark:text-white mt-1.5">
+                            {{ formatNumber(analytics.activation.signupsCount) }}
                         </p>
                     </div>
                 </div>
             </div>
 
             <!-- Secondary Stats Row -->
-            <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
-                <div
-                    class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 sm:p-5 min-h-[7.5rem] flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 min-w-0"
-                >
+            <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-8">
+                <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700/50 p-5 flex items-center justify-between">
                     <div class="min-w-0">
-                        <p
-                            class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate"
-                        >
-                            Active (7 Days)
-                        </p>
-                        <p
-                            class="text-xl font-semibold text-gray-900 dark:text-white truncate mt-1"
-                            :title="formatNumber(analytics.summary.active7Days)"
-                        >
+                        <p class="text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500">Active (7 Days)</p>
+                        <p class="text-xl font-bold text-gray-900 dark:text-white mt-1">
                             {{ formatNumber(analytics.summary.active7Days) }}
                         </p>
                     </div>
-                    <p
-                        class="text-sm text-gray-500 dark:text-gray-400 flex-shrink-0 sm:text-right"
-                    >
-                        {{
-                            calculatePercentage(
-                                analytics.summary.active7Days,
-                                analytics.summary.totalUsers,
-                            )
-                        }}% of users
-                    </p>
+                    <span class="text-sm font-medium text-gray-400 dark:text-gray-500 flex-shrink-0">
+                        {{ calculatePercentage(analytics.summary.active7Days, analytics.summary.totalUsers) }}%
+                    </span>
                 </div>
 
-                <div
-                    class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 sm:p-5 min-h-[7.5rem] flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 min-w-0"
-                >
+                <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700/50 p-5 flex items-center justify-between">
                     <div class="min-w-0">
-                        <p
-                            class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate"
-                        >
-                            Active (30 Days)
-                        </p>
-                        <p
-                            class="text-xl font-semibold text-gray-900 dark:text-white truncate mt-1"
-                            :title="
-                                formatNumber(analytics.summary.active30Days)
-                            "
-                        >
+                        <p class="text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500">Active (30 Days)</p>
+                        <p class="text-xl font-bold text-gray-900 dark:text-white mt-1">
                             {{ formatNumber(analytics.summary.active30Days) }}
                         </p>
                     </div>
-                    <p
-                        class="text-sm text-gray-500 dark:text-gray-400 flex-shrink-0 sm:text-right"
-                    >
-                        {{
-                            calculatePercentage(
-                                analytics.summary.active30Days,
-                                analytics.summary.totalUsers,
-                            )
-                        }}% of users
-                    </p>
+                    <span class="text-sm font-medium text-gray-400 dark:text-gray-500 flex-shrink-0">
+                        {{ calculatePercentage(analytics.summary.active30Days, analytics.summary.totalUsers) }}%
+                    </span>
                 </div>
 
-                <div
-                    class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 sm:p-5 min-h-[7.5rem] flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 min-w-0"
-                >
+                <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700/50 p-5 flex items-center justify-between">
                     <div class="min-w-0">
-                        <p
-                            class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate"
-                        >
-                            API Calls
-                        </p>
-                        <p
-                            class="text-xl font-semibold text-gray-900 dark:text-white truncate mt-1"
-                            :title="formatNumber(analytics.summary.apiCalls)"
-                        >
+                        <p class="text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500">API Calls</p>
+                        <p class="text-xl font-bold text-gray-900 dark:text-white mt-1">
                             {{ formatNumber(analytics.summary.apiCalls) }}
                         </p>
                     </div>
-                    <p
-                        class="text-sm text-gray-500 dark:text-gray-400 flex-shrink-0 sm:text-right"
-                    >
-                        {{ formatNumber(analytics.summary.importCount) }}
-                        imports
-                    </p>
+                    <span class="text-sm font-medium text-gray-400 dark:text-gray-500 flex-shrink-0">
+                        {{ formatNumber(analytics.summary.importCount) }} imports
+                    </span>
                 </div>
             </div>
 
             <!-- Charts Grid -->
-            <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
-                <!-- Signup Trend Chart -->
-                <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
-                    <h3
-                        class="text-lg font-medium text-gray-900 dark:text-white mb-4"
-                    >
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-8">
+                <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700/50 p-6">
+                    <h3 class="text-sm font-semibold text-gray-900 dark:text-white mb-4">
                         Signup Trend
                     </h3>
                     <div class="h-64">
@@ -720,11 +385,8 @@
                     </div>
                 </div>
 
-                <!-- Login Activity Chart -->
-                <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
-                    <h3
-                        class="text-lg font-medium text-gray-900 dark:text-white mb-4"
-                    >
+                <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700/50 p-6">
+                    <h3 class="text-sm font-semibold text-gray-900 dark:text-white mb-4">
                         Login Activity
                     </h3>
                     <div class="h-64">
@@ -744,11 +406,8 @@
                     </div>
                 </div>
 
-                <!-- Import Trend Chart -->
-                <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
-                    <h3
-                        class="text-lg font-medium text-gray-900 dark:text-white mb-4"
-                    >
+                <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700/50 p-6">
+                    <h3 class="text-sm font-semibold text-gray-900 dark:text-white mb-4">
                         Import Activity
                     </h3>
                     <div class="h-64">
@@ -768,11 +427,8 @@
                     </div>
                 </div>
 
-                <!-- API Usage Chart -->
-                <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
-                    <h3
-                        class="text-lg font-medium text-gray-900 dark:text-white mb-4"
-                    >
+                <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700/50 p-6">
+                    <h3 class="text-sm font-semibold text-gray-900 dark:text-white mb-4">
                         API Usage
                     </h3>
                     <div class="h-64">
@@ -792,11 +448,8 @@
                     </div>
                 </div>
 
-                <!-- Account Deletions Chart -->
-                <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
-                    <h3
-                        class="text-lg font-medium text-gray-900 dark:text-white mb-4"
-                    >
+                <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700/50 p-6">
+                    <h3 class="text-sm font-semibold text-gray-900 dark:text-white mb-4">
                         Account Deletions
                     </h3>
                     <div class="h-64">
@@ -821,86 +474,61 @@
             </div>
 
             <!-- Broker Sync Stats -->
-            <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
-                <h3
-                    class="text-lg font-medium text-gray-900 dark:text-white mb-4"
-                >
+            <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700/50 p-6">
+                <h3 class="text-sm font-semibold text-gray-900 dark:text-white mb-4">
                     Broker Sync Statistics
                 </h3>
                 <div class="grid grid-cols-2 sm:grid-cols-5 gap-4">
                     <div class="text-center">
-                        <p
-                            class="text-2xl font-semibold text-gray-900 dark:text-white"
-                        >
+                        <p class="text-2xl font-bold text-gray-900 dark:text-white">
                             {{ formatNumber(analytics.brokerSync.totalSyncs) }}
                         </p>
-                        <p class="text-sm text-gray-500 dark:text-gray-400">
+                        <p class="text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500 mt-1">
                             Total Syncs
                         </p>
                     </div>
                     <div class="text-center">
-                        <p
-                            class="text-2xl font-semibold text-green-600 dark:text-green-400"
-                        >
-                            {{
-                                formatNumber(
-                                    analytics.brokerSync.successfulSyncs,
-                                )
-                            }}
+                        <p class="text-2xl font-bold text-green-600 dark:text-green-400">
+                            {{ formatNumber(analytics.brokerSync.successfulSyncs) }}
                         </p>
-                        <p class="text-sm text-gray-500 dark:text-gray-400">
+                        <p class="text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500 mt-1">
                             Successful
                         </p>
                     </div>
                     <div class="text-center">
-                        <p
-                            class="text-2xl font-semibold text-red-600 dark:text-red-400"
-                        >
+                        <p class="text-2xl font-bold text-red-600 dark:text-red-400">
                             {{ formatNumber(analytics.brokerSync.failedSyncs) }}
                         </p>
-                        <p class="text-sm text-gray-500 dark:text-gray-400">
+                        <p class="text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500 mt-1">
                             Failed
                         </p>
                     </div>
                     <div class="text-center">
-                        <p
-                            class="text-2xl font-semibold text-blue-600 dark:text-blue-400"
-                        >
-                            {{
-                                formatNumber(
-                                    analytics.brokerSync.tradesImported,
-                                )
-                            }}
+                        <p class="text-2xl font-bold text-primary-600 dark:text-primary-400">
+                            {{ formatNumber(analytics.brokerSync.tradesImported) }}
                         </p>
-                        <p class="text-sm text-gray-500 dark:text-gray-400">
+                        <p class="text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500 mt-1">
                             Trades Synced
                         </p>
                     </div>
                     <div class="text-center">
-                        <p
-                            class="text-2xl font-semibold text-gray-600 dark:text-gray-400"
-                        >
-                            {{
-                                formatNumber(analytics.brokerSync.tradesSkipped)
-                            }}
+                        <p class="text-2xl font-bold text-gray-600 dark:text-gray-400">
+                            {{ formatNumber(analytics.brokerSync.tradesSkipped) }}
                         </p>
-                        <p class="text-sm text-gray-500 dark:text-gray-400">
+                        <p class="text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500 mt-1">
                             Duplicates Skipped
                         </p>
                     </div>
                 </div>
             </div>
 
-            <!-- Unknown CSV Headers (no parser match or parse failed) -->
-            <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6 mt-8">
-                <h3
-                    class="text-lg font-medium text-gray-900 dark:text-white mb-4"
-                >
+            <!-- Unknown CSV Headers -->
+            <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700/50 p-6 mt-6">
+                <h3 class="text-sm font-semibold text-gray-900 dark:text-white mb-1">
                     Unknown CSV Headers
                 </h3>
-                <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
-                    Imports that did not match a known broker or failed to
-                    parse. Use these to add or improve parsers.
+                <p class="text-xs text-gray-500 dark:text-gray-400 mb-4">
+                    Imports that did not match a known broker or failed to parse.
                 </p>
                 <div
                     v-if="unknownCsvHeadersLoading"
@@ -923,34 +551,22 @@
                         >
                             <thead>
                                 <tr>
-                                    <th
-                                        class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase"
-                                    >
+                                    <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
                                         Outcome
                                     </th>
-                                    <th
-                                        class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase"
-                                    >
+                                    <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
                                         Broker
                                     </th>
-                                    <th
-                                        class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase"
-                                    >
+                                    <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
                                         Headers
                                     </th>
-                                    <th
-                                        class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase"
-                                    >
+                                    <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
                                         File
                                     </th>
-                                    <th
-                                        class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase"
-                                    >
+                                    <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
                                         Date
                                     </th>
-                                    <th
-                                        class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase"
-                                    >
+                                    <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
                                         Copy
                                     </th>
                                 </tr>
@@ -966,19 +582,10 @@
                                         class="text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
                                         @click="toggleExpandedRow(row.id)"
                                     >
-                                        <td
-                                            class="px-3 py-2 text-gray-900 dark:text-white"
-                                        >
-                                            <span
-                                                :class="
-                                                    outcomeClass(row.outcome)
-                                                "
-                                                >{{ row.outcome }}</span
-                                            >
+                                        <td class="px-3 py-2 text-gray-900 dark:text-white">
+                                            <span :class="outcomeClass(row.outcome)">{{ row.outcome }}</span>
                                         </td>
-                                        <td
-                                            class="px-3 py-2 text-gray-600 dark:text-gray-300"
-                                        >
+                                        <td class="px-3 py-2 text-gray-600 dark:text-gray-300">
                                             {{ row.broker_attempted }}
                                         </td>
                                         <td
@@ -987,33 +594,19 @@
                                         >
                                             {{ row.header_line }}
                                         </td>
-                                        <td
-                                            class="px-3 py-2 text-gray-600 dark:text-gray-300"
-                                        >
+                                        <td class="px-3 py-2 text-gray-600 dark:text-gray-300">
                                             {{ row.file_name || "-" }}
                                         </td>
-                                        <td
-                                            class="px-3 py-2 text-gray-500 dark:text-gray-400 whitespace-nowrap"
-                                        >
-                                            {{
-                                                formatUnknownCsvDate(
-                                                    row.created_at,
-                                                )
-                                            }}
+                                        <td class="px-3 py-2 text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                                            {{ formatUnknownCsvDate(row.created_at) }}
                                         </td>
                                         <td class="px-3 py-2">
                                             <button
-                                                @click.stop="
-                                                    copyHeaderLine(row)
-                                                "
+                                                @click.stop="copyHeaderLine(row)"
                                                 class="text-xs px-2 py-1 rounded bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
                                                 :title="'Copy header line'"
                                             >
-                                                {{
-                                                    copiedRowId === row.id
-                                                        ? "Copied!"
-                                                        : "Copy"
-                                                }}
+                                                {{ copiedRowId === row.id ? "Copied!" : "Copy" }}
                                             </button>
                                         </td>
                                     </tr>
@@ -1025,191 +618,58 @@
                                         >
                                             <div class="space-y-3 text-sm">
                                                 <div>
-                                                    <div
-                                                        class="flex items-center justify-between mb-1"
-                                                    >
-                                                        <span
-                                                            class="font-medium text-gray-700 dark:text-gray-300"
-                                                            >Header Line</span
-                                                        >
+                                                    <div class="flex items-center justify-between mb-1">
+                                                        <span class="font-medium text-gray-700 dark:text-gray-300">Header Line</span>
                                                         <button
-                                                            @click="
-                                                                copyToClipboard(
-                                                                    row.header_line,
-                                                                    'header-' +
-                                                                        row.id,
-                                                                )
-                                                            "
+                                                            @click="copyToClipboard(row.header_line, 'header-' + row.id)"
                                                             class="text-xs px-2 py-0.5 rounded bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
                                                         >
-                                                            {{
-                                                                clipboardFeedback ===
-                                                                "header-" +
-                                                                    row.id
-                                                                    ? "Copied!"
-                                                                    : "Copy"
-                                                            }}
+                                                            {{ clipboardFeedback === 'header-' + row.id ? 'Copied!' : 'Copy' }}
                                                         </button>
                                                     </div>
-                                                    <pre
-                                                        class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded p-2 text-xs text-gray-800 dark:text-gray-200 overflow-x-auto whitespace-pre-wrap break-all"
-                                                        >{{
-                                                            row.header_line
-                                                        }}</pre
-                                                    >
+                                                    <pre class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded p-2 text-xs text-gray-800 dark:text-gray-200 overflow-x-auto whitespace-pre-wrap break-all">{{ row.header_line }}</pre>
                                                 </div>
                                                 <div v-if="row.sample_data">
-                                                    <div
-                                                        class="flex items-center justify-between mb-1"
-                                                    >
-                                                        <span
-                                                            class="font-medium text-gray-700 dark:text-gray-300"
-                                                            >Sample Data (first
-                                                            rows)</span
-                                                        >
+                                                    <div class="flex items-center justify-between mb-1">
+                                                        <span class="font-medium text-gray-700 dark:text-gray-300">Sample Data (first rows)</span>
                                                         <button
-                                                            @click="
-                                                                copyToClipboard(
-                                                                    row.header_line +
-                                                                        '\n' +
-                                                                        row.sample_data,
-                                                                    'sample-' +
-                                                                        row.id,
-                                                                )
-                                                            "
+                                                            @click="copyToClipboard(row.header_line + '\n' + row.sample_data, 'sample-' + row.id)"
                                                             class="text-xs px-2 py-0.5 rounded bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
                                                         >
-                                                            {{
-                                                                clipboardFeedback ===
-                                                                "sample-" +
-                                                                    row.id
-                                                                    ? "Copied!"
-                                                                    : "Copy Header + Data"
-                                                            }}
+                                                            {{ clipboardFeedback === 'sample-' + row.id ? 'Copied!' : 'Copy Header + Data' }}
                                                         </button>
                                                     </div>
-                                                    <pre
-                                                        class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded p-2 text-xs text-gray-800 dark:text-gray-200 overflow-x-auto whitespace-pre-wrap break-all"
-                                                        >{{
-                                                            row.sample_data
-                                                        }}</pre
-                                                    >
+                                                    <pre class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded p-2 text-xs text-gray-800 dark:text-gray-200 overflow-x-auto whitespace-pre-wrap break-all">{{ row.sample_data }}</pre>
                                                 </div>
-                                                <div
-                                                    class="grid grid-cols-2 md:grid-cols-4 gap-3"
-                                                >
-                                                    <div
-                                                        v-if="
-                                                            row.detected_broker
-                                                        "
-                                                    >
-                                                        <span
-                                                            class="text-gray-500 dark:text-gray-400"
-                                                            >Detected
-                                                            Broker:</span
-                                                        >
-                                                        <span
-                                                            class="ml-1 text-gray-900 dark:text-white"
-                                                            >{{
-                                                                row.detected_broker
-                                                            }}</span
-                                                        >
+                                                <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+                                                    <div v-if="row.detected_broker">
+                                                        <span class="text-gray-500 dark:text-gray-400">Detected Broker:</span>
+                                                        <span class="ml-1 text-gray-900 dark:text-white">{{ row.detected_broker }}</span>
                                                     </div>
-                                                    <div
-                                                        v-if="
-                                                            row.selected_broker
-                                                        "
-                                                    >
-                                                        <span
-                                                            class="text-gray-500 dark:text-gray-400"
-                                                            >Selected
-                                                            Broker:</span
-                                                        >
-                                                        <span
-                                                            class="ml-1 text-gray-900 dark:text-white"
-                                                            >{{
-                                                                row.selected_broker
-                                                            }}</span
-                                                        >
+                                                    <div v-if="row.selected_broker">
+                                                        <span class="text-gray-500 dark:text-gray-400">Selected Broker:</span>
+                                                        <span class="ml-1 text-gray-900 dark:text-white">{{ row.selected_broker }}</span>
                                                     </div>
-                                                    <div
-                                                        v-if="
-                                                            row.row_count !=
-                                                            null
-                                                        "
-                                                    >
-                                                        <span
-                                                            class="text-gray-500 dark:text-gray-400"
-                                                            >CSV Rows:</span
-                                                        >
-                                                        <span
-                                                            class="ml-1 text-gray-900 dark:text-white"
-                                                            >{{
-                                                                row.row_count
-                                                            }}</span
-                                                        >
+                                                    <div v-if="row.row_count != null">
+                                                        <span class="text-gray-500 dark:text-gray-400">CSV Rows:</span>
+                                                        <span class="ml-1 text-gray-900 dark:text-white">{{ row.row_count }}</span>
                                                     </div>
-                                                    <div
-                                                        v-if="
-                                                            row.trades_parsed !=
-                                                            null
-                                                        "
-                                                    >
-                                                        <span
-                                                            class="text-gray-500 dark:text-gray-400"
-                                                            >Trades
-                                                            Parsed:</span
-                                                        >
-                                                        <span
-                                                            class="ml-1 text-gray-900 dark:text-white"
-                                                            >{{
-                                                                row.trades_parsed
-                                                            }}</span
-                                                        >
+                                                    <div v-if="row.trades_parsed != null">
+                                                        <span class="text-gray-500 dark:text-gray-400">Trades Parsed:</span>
+                                                        <span class="ml-1 text-gray-900 dark:text-white">{{ row.trades_parsed }}</span>
                                                     </div>
                                                 </div>
-                                                <div
-                                                    v-if="row.diagnostics_json"
-                                                >
-                                                    <div
-                                                        class="flex items-center justify-between mb-1"
-                                                    >
-                                                        <span
-                                                            class="font-medium text-gray-700 dark:text-gray-300"
-                                                            >Diagnostics</span
-                                                        >
+                                                <div v-if="row.diagnostics_json">
+                                                    <div class="flex items-center justify-between mb-1">
+                                                        <span class="font-medium text-gray-700 dark:text-gray-300">Diagnostics</span>
                                                         <button
-                                                            @click="
-                                                                copyToClipboard(
-                                                                    JSON.stringify(
-                                                                        row.diagnostics_json,
-                                                                        null,
-                                                                        2,
-                                                                    ),
-                                                                    'diag-' +
-                                                                        row.id,
-                                                                )
-                                                            "
+                                                            @click="copyToClipboard(JSON.stringify(row.diagnostics_json, null, 2), 'diag-' + row.id)"
                                                             class="text-xs px-2 py-0.5 rounded bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
                                                         >
-                                                            {{
-                                                                clipboardFeedback ===
-                                                                "diag-" + row.id
-                                                                    ? "Copied!"
-                                                                    : "Copy"
-                                                            }}
+                                                            {{ clipboardFeedback === 'diag-' + row.id ? 'Copied!' : 'Copy' }}
                                                         </button>
                                                     </div>
-                                                    <pre
-                                                        class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded p-2 text-xs text-gray-800 dark:text-gray-200 overflow-x-auto max-h-48 overflow-y-auto"
-                                                        >{{
-                                                            JSON.stringify(
-                                                                row.diagnostics_json,
-                                                                null,
-                                                                2,
-                                                            )
-                                                        }}</pre
-                                                    >
+                                                    <pre class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded p-2 text-xs text-gray-800 dark:text-gray-200 overflow-x-auto max-h-48 overflow-y-auto">{{ JSON.stringify(row.diagnostics_json, null, 2) }}</pre>
                                                 </div>
                                             </div>
                                         </td>
@@ -1226,14 +686,8 @@
                     >
                         <p class="text-sm text-gray-500 dark:text-gray-400">
                             Showing
-                            {{
-                                (csvPagination.page - 1) * csvPagination.limit +
-                                1
-                            }}-{{
-                                Math.min(
-                                    csvPagination.page * csvPagination.limit,
-                                    csvPagination.total,
-                                )
+                            {{ (csvPagination.page - 1) * csvPagination.limit + 1 }}-{{
+                                Math.min(csvPagination.page * csvPagination.limit, csvPagination.total)
                             }}
                             of {{ csvPagination.total }}
                         </p>
@@ -1245,18 +699,12 @@
                             >
                                 Previous
                             </button>
-                            <span
-                                class="text-sm text-gray-600 dark:text-gray-400"
-                            >
-                                Page {{ csvPagination.page }} of
-                                {{ csvPagination.totalPages }}
+                            <span class="text-sm text-gray-600 dark:text-gray-400">
+                                Page {{ csvPagination.page }} of {{ csvPagination.totalPages }}
                             </span>
                             <button
                                 @click="changeCsvPage(csvPagination.page + 1)"
-                                :disabled="
-                                    csvPagination.page >=
-                                    csvPagination.totalPages
-                                "
+                                :disabled="csvPagination.page >= csvPagination.totalPages"
                                 class="px-3 py-1 text-sm rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                             >
                                 Next
@@ -1270,9 +718,11 @@
 </template>
 
 <script setup>
-import { ref, watch, onMounted, onUnmounted } from "vue";
+import { ref, computed, watch, onMounted, onUnmounted } from "vue";
 import api from "@/services/api";
 import AdminLineChart from "@/components/admin/AdminLineChart.vue";
+
+const REFRESH_INTERVAL = 60000; // 60 seconds
 
 const periods = [
     { label: "Today", value: "today" },
@@ -1288,6 +738,7 @@ const selectedPeriod = ref(savedPeriod || "30d");
 
 const analytics = ref(null);
 const loading = ref(true);
+const initialLoading = ref(true);
 const error = ref(null);
 const unknownCsvHeaders = ref([]);
 const unknownCsvHeadersLoading = ref(false);
@@ -1297,7 +748,27 @@ const showExpiredTrialUsers = ref(false);
 const copiedRowId = ref(null);
 const clipboardFeedback = ref(null);
 const activeConnections = ref(null);
+const lastUpdated = ref(null);
 let connectionsInterval = null;
+let refreshInterval = null;
+
+const lastUpdatedText = computed(() => {
+    if (!lastUpdated.value) return "";
+    const seconds = Math.round((Date.now() - lastUpdated.value) / 1000);
+    if (seconds < 5) return "just now";
+    if (seconds < 60) return `${seconds}s ago`;
+    const minutes = Math.round(seconds / 60);
+    return `${minutes}m ago`;
+});
+
+// Update the "X ago" text every 10 seconds
+let lastUpdatedTimer = null;
+function startLastUpdatedTimer() {
+    lastUpdatedTimer = setInterval(() => {
+        // Force reactivity by touching the ref
+        if (lastUpdated.value) lastUpdated.value = lastUpdated.value;
+    }, 10000);
+}
 
 function formatNumber(num) {
     if (num === null || num === undefined) return "0";
@@ -1386,7 +857,7 @@ function outcomeClass(outcome) {
         zero_trades: "text-orange-600 dark:text-orange-400",
         zero_imported: "text-orange-600 dark:text-orange-400",
         high_skip_rate: "text-yellow-600 dark:text-yellow-400",
-        mismatch_override: "text-blue-600 dark:text-blue-400",
+        mismatch_override: "text-primary-600 dark:text-primary-400",
     };
     return classes[outcome] || "text-gray-900 dark:text-white";
 }
@@ -1429,17 +900,21 @@ async function fetchAnalytics() {
             `/admin/analytics?period=${selectedPeriod.value}`,
         );
         analytics.value = response.data;
+        lastUpdated.value = Date.now();
     } catch (err) {
         console.error("[ERROR] Failed to fetch analytics:", err);
-        error.value =
-            err.response?.data?.error || "Failed to load analytics data";
+        // Only show error on initial load — silent fail on auto-refresh
+        if (initialLoading.value) {
+            error.value =
+                err.response?.data?.error || "Failed to load analytics data";
+        }
     } finally {
         loading.value = false;
+        initialLoading.value = false;
     }
 }
 
 watch(selectedPeriod, (newPeriod) => {
-    // Save to localStorage when period changes
     localStorage.setItem("adminAnalyticsPeriod", newPeriod);
     fetchAnalytics();
 });
@@ -1458,11 +933,13 @@ onMounted(() => {
     fetchUnknownCsvHeaders();
     fetchActiveConnections();
     connectionsInterval = setInterval(fetchActiveConnections, 30000);
+    refreshInterval = setInterval(fetchAnalytics, REFRESH_INTERVAL);
+    startLastUpdatedTimer();
 });
 
 onUnmounted(() => {
-    if (connectionsInterval) {
-        clearInterval(connectionsInterval);
-    }
+    if (connectionsInterval) clearInterval(connectionsInterval);
+    if (refreshInterval) clearInterval(refreshInterval);
+    if (lastUpdatedTimer) clearInterval(lastUpdatedTimer);
 });
 </script>


### PR DESCRIPTION
Add 60-second auto-refresh with initialLoading pattern to keep data current without page reloads. Consolidate Revenue + Paying Users and Trial Start Rate + Trial to Paid into combined cards with progress bars. Clean up card design with rounded-xl borders and typography-forward layout.