### PR TITLE
feat(achievements): batch 2 — review and planning

### DIFF
--- a/backend/migrations/187_add_review_and_planning_achievements_batch2.sql
+++ b/backend/migrations/187_add_review_and_planning_achievements_batch2.sql
@@ -1,0 +1,49 @@
+-- Batch 2 achievement rollout focused on planning quality and playbook usage
+
+UPDATE achievements
+SET
+  name = 'Cooldown Respected',
+  description = 'Use a cooling period after at least 80% of losses in a 30 day window',
+  points = 90,
+  criteria = '{"type": "cooling_period_usage", "percentage": 80}'
+WHERE key = 'cool_head';
+
+INSERT INTO achievements (key, name, description, category, difficulty, points, criteria)
+VALUES
+  (
+    'playbook_builder',
+    'Playbook Builder',
+    'Create 3 active playbooks for your setups',
+    'learning',
+    'bronze',
+    70,
+    '{"type": "active_playbooks", "count": 3}'
+  ),
+  (
+    'detailed_planner',
+    'Detailed Planner',
+    'Complete 15 closed trades with both a stop loss and a take profit defined',
+    'behavioral',
+    'silver',
+    90,
+    '{"type": "planned_trades", "count": 15}'
+  ),
+  (
+    'data_hygiene',
+    'Data Hygiene',
+    'Maintain complete setup, risk, and journal detail on 20 closed trades',
+    'learning',
+    'silver',
+    100,
+    '{"type": "trade_data_hygiene", "count": 20, "min_length": 20}'
+  ),
+  (
+    'a_plus_execution',
+    'A+ Execution',
+    'Log 10 reviewed trades with high adherence and confirmed plan-following',
+    'behavioral',
+    'gold',
+    125,
+    '{"type": "high_adherence_reviews", "count": 10, "threshold": 85}'
+  )
+ON CONFLICT (key) DO NOTHING;

--- a/backend/src/controllers/playbook.controller.js
+++ b/backend/src/controllers/playbook.controller.js
@@ -87,6 +87,13 @@ const playbookController = {
   async createPlaybook(req, res, next) {
     try {
       const playbook = await Playbook.create(req.user.id, req.body);
+
+      try {
+        await AchievementService.checkAndAwardAchievements(req.user.id);
+      } catch (achievementError) {
+        console.warn(`Failed to check achievements for user ${req.user.id} after playbook creation:`, achievementError.message);
+      }
+
       res.status(201).json({ playbook: mapPlaybook(playbook) });
     } catch (error) {
       if (error.code === '23505') {

--- a/backend/src/services/achievementService.js
+++ b/backend/src/services/achievementService.js
@@ -128,9 +128,21 @@ class AchievementService {
 
       case 'closed_trades_with_stop_loss':
         return await AchievementService.checkClosedTradesWithStopLoss(userId, criteria.count);
+
+      case 'active_playbooks':
+        return await AchievementService.checkActivePlaybooks(userId, criteria.count);
         
       case 'cooling_period_usage':
         return await AchievementService.checkCoolingPeriodUsage(userId, criteria.percentage);
+
+      case 'planned_trades':
+        return await AchievementService.checkPlannedTrades(userId, criteria.count);
+
+      case 'trade_data_hygiene':
+        return await AchievementService.checkTradeDataHygiene(userId, criteria.count, criteria.min_length);
+
+      case 'high_adherence_reviews':
+        return await AchievementService.checkHighAdherenceReviews(userId, criteria.count, criteria.threshold);
         
       case 'weekly_pnl':
         return await AchievementService.checkWeeklyPnL(userId, criteria.positive);
@@ -433,7 +445,28 @@ class AchievementService {
 
     return false;
   }
-  
+
+  static async checkActivePlaybooks(userId, requiredCount) {
+    const result = await db.query(`
+      SELECT COUNT(*)::int AS active_playbook_count
+      FROM playbooks
+      WHERE user_id = $1
+        AND is_active = true
+    `, [userId]);
+
+    if (result.rows[0].active_playbook_count >= requiredCount) {
+      return {
+        earned: true,
+        metadata: {
+          active_playbook_count: result.rows[0].active_playbook_count,
+          required_count: requiredCount
+        }
+      };
+    }
+
+    return false;
+  }
+
   // Check cooling period usage
   static async checkCoolingPeriodUsage(userId, percentage) {
     const query = `
@@ -513,6 +546,60 @@ class AchievementService {
     return false;
   }
 
+  static async checkPlannedTrades(userId, requiredTrades) {
+    const result = await db.query(`
+      SELECT COUNT(*)::int AS qualifying_trades
+      FROM trades
+      WHERE user_id = $1
+        AND exit_time IS NOT NULL
+        AND stop_loss IS NOT NULL
+        AND take_profit IS NOT NULL
+    `, [userId]);
+
+    if (result.rows[0].qualifying_trades >= requiredTrades) {
+      return {
+        earned: true,
+        metadata: {
+          qualifying_trades: result.rows[0].qualifying_trades,
+          required_trades: requiredTrades
+        }
+      };
+    }
+
+    return false;
+  }
+
+  static async checkTradeDataHygiene(userId, requiredTrades, minLength = 20) {
+    const result = await db.query(`
+      SELECT COUNT(*)::int AS qualifying_trades
+      FROM trades t
+      LEFT JOIN trade_playbook_reviews r
+        ON r.trade_id = t.id
+       AND r.user_id = t.user_id
+      WHERE t.user_id = $1
+        AND t.exit_time IS NOT NULL
+        AND t.stop_loss IS NOT NULL
+        AND LENGTH(BTRIM(COALESCE(t.setup, ''))) > 0
+        AND (
+          LENGTH(BTRIM(COALESCE(t.notes, ''))) >= $2
+          OR LENGTH(BTRIM(COALESCE(r.review_notes, ''))) >= $2
+        )
+    `, [userId, minLength]);
+
+    if (result.rows[0].qualifying_trades >= requiredTrades) {
+      return {
+        earned: true,
+        metadata: {
+          qualifying_trades: result.rows[0].qualifying_trades,
+          required_trades: requiredTrades,
+          min_length: minLength
+        }
+      };
+    }
+
+    return false;
+  }
+
   static async checkReviewHabit(userId, requiredReviews, days) {
     const result = await db.query(`
       SELECT COUNT(*)::int AS completed_reviews
@@ -559,7 +646,34 @@ class AchievementService {
 
     return false;
   }
-  
+
+  static async checkHighAdherenceReviews(userId, requiredReviews, threshold) {
+    const result = await db.query(`
+      SELECT COUNT(*)::int AS qualifying_reviews
+      FROM trade_playbook_reviews r
+      INNER JOIN trades t
+        ON t.id = r.trade_id
+       AND t.user_id = r.user_id
+      WHERE r.user_id = $1
+        AND t.exit_time IS NOT NULL
+        AND r.followed_plan = true
+        AND COALESCE(r.adherence_score, 0) >= $2
+    `, [userId, threshold]);
+
+    if (result.rows[0].qualifying_reviews >= requiredReviews) {
+      return {
+        earned: true,
+        metadata: {
+          qualifying_reviews: result.rows[0].qualifying_reviews,
+          required_reviews: requiredReviews,
+          threshold
+        }
+      };
+    }
+
+    return false;
+  }
+
   // Check weekly P&L
   static async checkWeeklyPnL(userId, mustBePositive) {
     const query = `


### PR DESCRIPTION
## Summary
Adds the second batch of process-focused achievements (planning quality and playbook usage), one new migration, and an achievement-award trigger on playbook creation.

New achievement criteria:
- `active_playbooks`
- `planned_trades`
- `trade_data_hygiene`
- `high_adherence_reviews`

## Notes
- Rebased onto current develop.
- Migration renumbered from 176 → 187 to slot above the existing develop head (186).
- `achievementService.js` switch + method additions merged alongside develop's `closed_trades_with_stop_loss` work.

## Test plan
- [ ] Migration applies cleanly on a develop-state DB
- [ ] Existing batch-1 achievements still evaluate
- [ ] Creating a playbook triggers achievement check without throwing