### PR TITLE
fix: crash on cross-import close — strip totalCommission before Trade.update()

### DIFF
--- a/backend/src/controllers/trade.controller.js
+++ b/backend/src/controllers/trade.controller.js
@@ -2638,6 +2638,7 @@ const tradeController = {
                   existingTradeId, isUpdate, executionData, totalFees, totalFeesForSymbol,
                   pnl, pnlPercent, profitLoss, newExecutionsAdded,
                   groupedTrades, originalNotes, existingExecutions,
+                  totalCommission, // internal accumulator — not a DB column
                   ...cleanTradeData
                 } = tradeData;
 


### PR DESCRIPTION
## Problem

Importing a position across two sessions (open in Import A, close in Import B) crashes with: column "total_commission" of relation "trades" does not exist

## Root cause

`parseGenericTransactions` maintains `totalCommission` as an internal running accumulator on each trade object — it is never deleted after the trade is finalized. `Trade.update()` uses a dynamic `Object.entries()` loop to build the SQL `SET` clause (no column whitelist), so `totalCommission` on the object becomes `SET total_commission = $N`, a column that does not exist.

The same-file open+close path is unaffected because it calls `Trade.create()`, which uses explicit parameter destructuring and silently ignores unknown fields.

## Why only cross-import closes are affected

When a position opened in Import A is closed in Import B, `parseGenericTransactions` re-initializes `totalCommission` from the saved `existingPosition.commission`, accumulates new exit executions into it, and sets `isUpdate: true` + `existingTradeId` on the object. The controller then routes it to `Trade.update()` with `totalCommission` still present.

## Fix

Add `totalCommission` to the destructuring block in `trade.controller.js` (~line 2638) that already strips ~15 other internal fields (`totalQuantity`, `entryValue`, `isUpdate`, `executionData`, etc.) before calling `Trade.update()`.

## Note for maintainers

A scan of other parsers found one structurally similar risk: `realizedPnl` set by the Tradovate parsers (csvParser.js ~lines 10802, 11264) also sets `isUpdate: true` and `existingTradeId` on cross-import closes, and `realizedPnl` is absent from the same destructuring block. It would produce the same crash (`column "realized_pnl" does not exist`) for Tradovate users on cross-import closes. Not included here as it cannot be validated without a Tradovate account — flagging for awareness.