### PR TITLE
fix: preserve configured AI API keys

### DIFF
--- a/backend/src/controllers/settings.controller.js
+++ b/backend/src/controllers/settings.controller.js
@@ -2080,6 +2080,7 @@ const settingsController = {
 
       const { cusipAiProvider, cusipAiApiKey, cusipAiApiUrl, cusipAiModel, useMainProvider } = req.body;
       const normalizedProvider = cusipAiProvider ? String(cusipAiProvider).trim() : '';
+      const apiKeyUpdate = cusipAiApiKey === '***' ? undefined : cusipAiApiKey;
 
       // If useMainProvider is true, clear CUSIP-specific settings
       if (useMainProvider || !normalizedProvider) {
@@ -2131,7 +2132,7 @@ const settingsController = {
 
       const success = await adminSettingsService.updateDefaultCusipAISettings({
         provider: normalizedProvider,
-        apiKey: cusipAiApiKey,
+        apiKey: apiKeyUpdate,
         apiUrl: cusipAiApiUrl,
         model: cusipAiModel
       });

--- a/backend/tests/controllers/settings.aiProviders.test.js
+++ b/backend/tests/controllers/settings.aiProviders.test.js
@@ -187,4 +187,111 @@ describe('Custom AI provider settings', () => {
     });
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ cusipAiProvider: 'custom' }));
   });
+
+  test('preserves a user API key when only the model changes', async () => {
+    User.updateSettings.mockResolvedValue({
+      ai_provider: 'openai',
+      ai_api_key: 'stored-key',
+      ai_api_url: '',
+      ai_model: 'new-model'
+    });
+    const req = {
+      user: { id: 'user-1' },
+      body: {
+        aiProvider: 'openai',
+        aiApiKey: '***',
+        aiApiUrl: '',
+        aiModel: 'new-model'
+      }
+    };
+    const res = createResponse();
+
+    await settingsController.updateAIProviderSettings(req, res, jest.fn());
+
+    expect(User.updateSettings).toHaveBeenCalledWith('user-1', {
+      ai_provider: 'openai',
+      ai_api_url: '',
+      ai_model: 'new-model'
+    });
+  });
+
+  test('preserves a user CUSIP API key when only the model changes', async () => {
+    User.updateSettings.mockResolvedValue({
+      cusip_ai_provider: 'openai',
+      cusip_ai_api_key: 'stored-key',
+      cusip_ai_api_url: '',
+      cusip_ai_model: 'new-model'
+    });
+    const req = {
+      user: { id: 'user-1' },
+      body: {
+        cusipAiProvider: 'openai',
+        cusipAiApiKey: '***',
+        cusipAiApiUrl: '',
+        cusipAiModel: 'new-model',
+        useMainProvider: false
+      }
+    };
+    const res = createResponse();
+
+    await settingsController.updateCusipAIProviderSettings(req, res, jest.fn());
+
+    expect(User.updateSettings).toHaveBeenCalledWith('user-1', {
+      cusip_ai_provider: 'openai',
+      cusip_ai_api_url: '',
+      cusip_ai_model: 'new-model'
+    });
+  });
+
+  test('preserves the admin API key when only the model changes', async () => {
+    const req = {
+      user: { role: 'admin' },
+      body: {
+        aiProvider: 'openai',
+        aiApiKey: '***',
+        aiApiUrl: '',
+        aiModel: 'new-model',
+        aiClassifierEnabled: false,
+        aiClassifierProvider: '',
+        aiClassifierApiKey: '',
+        aiClassifierApiUrl: '',
+        aiClassifierModel: ''
+      }
+    };
+    const res = createResponse();
+
+    await settingsController.updateAdminAISettings(req, res, jest.fn());
+
+    expect(adminSettingsService.updateDefaultAISettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'openai',
+        apiKey: undefined,
+        model: 'new-model'
+      })
+    );
+  });
+
+  test('preserves the admin CUSIP API key when only the model changes', async () => {
+    const req = {
+      user: { role: 'admin' },
+      body: {
+        cusipAiProvider: 'openai',
+        cusipAiApiKey: '***',
+        cusipAiApiUrl: '',
+        cusipAiModel: 'new-model',
+        useMainProvider: false
+      }
+    };
+    const res = createResponse();
+
+    await settingsController.updateAdminCusipAISettings(req, res, jest.fn());
+
+    expect(adminSettingsService.updateDefaultCusipAISettings).toHaveBeenCalledWith({
+      provider: 'openai',
+      apiKey: undefined,
+      apiUrl: '',
+      model: 'new-model'
+    });
+  });
+
 });

--- a/frontend/src/components/settings/AdminAiProviderSettings.vue
+++ b/frontend/src/components/settings/AdminAiProviderSettings.vue
@@ -124,9 +124,14 @@
                         v-model="form.apiKey"
                         type="password"
                         class="input"
-                        :placeholder="getAdminApiKeyPlaceholder()"
+                        :placeholder="
+                            form.apiKeyConfigured
+                                ? 'API key saved — enter a new key to replace it'
+                                : getAdminApiKeyPlaceholder()
+                        "
                         :required="
                             !!form.provider &&
+                            !form.apiKeyConfigured &&
                             !OPTIONAL_API_KEY_AI_PROVIDERS.includes(form.provider)
                         "
                     />
@@ -265,10 +270,13 @@
                                 type="password"
                                 class="input"
                                 :placeholder="
-                                    getAdminClassifierApiKeyPlaceholder()
+                                    form.classifierApiKeyConfigured
+                                        ? 'API key saved — enter a new key to replace it'
+                                        : getAdminClassifierApiKeyPlaceholder()
                                 "
                                 :required="
                                     !!form.classifierProvider &&
+                                    !form.classifierApiKeyConfigured &&
                                     !OPTIONAL_API_KEY_AI_PROVIDERS.includes(form.classifierProvider)
                                 "
                             />
@@ -319,6 +327,7 @@ function onAdminProviderChange() {
     props.form.apiKey = "";
     props.form.url = "";
     props.form.model = "";
+    props.form.apiKeyConfigured = false;
     if (!props.form.classifierProvider) {
         props.form.classifierApiKey = "";
         props.form.classifierUrl = "";
@@ -332,6 +341,7 @@ function onAdminClassifierEnabledChange() {
         props.form.classifierApiKey = "";
         props.form.classifierUrl = "";
         props.form.classifierModel = "";
+        props.form.classifierApiKeyConfigured = false;
     }
 }
 
@@ -339,6 +349,7 @@ function onAdminClassifierProviderChange() {
     props.form.classifierApiKey = "";
     props.form.classifierUrl = "";
     props.form.classifierModel = "";
+    props.form.classifierApiKeyConfigured = false;
 }
 
 function getEffectiveAdminClassifierProvider() {

--- a/frontend/src/components/settings/AdminCusipAiProviderSettings.vue
+++ b/frontend/src/components/settings/AdminCusipAiProviderSettings.vue
@@ -124,10 +124,13 @@
                             type="password"
                             class="input"
                             :placeholder="
-                                getAdminCusipApiKeyPlaceholder()
+                                form.apiKeyConfigured
+                                    ? 'API key saved — enter a new key to replace it'
+                                    : getAdminCusipApiKeyPlaceholder()
                             "
                             :required="
                                 !!form.provider &&
+                                !form.apiKeyConfigured &&
                                 !OPTIONAL_API_KEY_AI_PROVIDERS.includes(form.provider)
                             "
                         />
@@ -178,6 +181,7 @@ function onAdminCusipProviderChange() {
     props.form.apiKey = "";
     props.form.url = "";
     props.form.model = "";
+    props.form.apiKeyConfigured = false;
 }
 
 function onAdminCusipUseMainProviderChange() {
@@ -186,6 +190,7 @@ function onAdminCusipUseMainProviderChange() {
         props.form.url = "";
         props.form.apiKey = "";
         props.form.model = "";
+        props.form.apiKeyConfigured = false;
     }
 }
 

--- a/frontend/src/components/settings/AiProviderSettings.vue
+++ b/frontend/src/components/settings/AiProviderSettings.vue
@@ -130,9 +130,14 @@
                         v-model="form.apiKey"
                         type="password"
                         class="input"
-                        :placeholder="getApiKeyPlaceholder()"
+                        :placeholder="
+                            form.apiKeyConfigured
+                                ? 'API key saved — enter a new key to replace it'
+                                : getApiKeyPlaceholder()
+                        "
                         :required="
                             !!form.provider &&
+                            !form.apiKeyConfigured &&
                             !OPTIONAL_API_KEY_AI_PROVIDERS.includes(form.provider)
                         "
                     />
@@ -270,5 +275,6 @@ function onProviderChange() {
     props.form.url = "";
     props.form.apiKey = "";
     props.form.model = "";
+    props.form.apiKeyConfigured = false;
 }
 </script>

--- a/frontend/src/components/settings/CusipAiProviderSettings.vue
+++ b/frontend/src/components/settings/CusipAiProviderSettings.vue
@@ -120,10 +120,13 @@
                             type="password"
                             class="input"
                             :placeholder="
-                                getCusipApiKeyPlaceholder()
+                                form.apiKeyConfigured
+                                    ? 'API key saved — enter a new key to replace it'
+                                    : getCusipApiKeyPlaceholder()
                             "
                             :required="
                                 !!form.provider &&
+                                !form.apiKeyConfigured &&
                                 !OPTIONAL_API_KEY_AI_PROVIDERS.includes(form.provider)
                             "
                         />
@@ -218,6 +221,7 @@ function onCusipProviderChange() {
     props.form.url = "";
     props.form.apiKey = "";
     props.form.model = "";
+    props.form.apiKeyConfigured = false;
 }
 
 function onCusipUseMainProviderChange() {
@@ -226,6 +230,7 @@ function onCusipUseMainProviderChange() {
         props.form.url = "";
         props.form.apiKey = "";
         props.form.model = "";
+        props.form.apiKeyConfigured = false;
     }
 }
 </script>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -16,11 +16,14 @@ app.use(createPinia())
 // navigation fires with the correct auth state. Installing it here would let
 // the router guard fire before the /auth/me response arrives, causing users
 // with a valid token cookie but a missing csrf_token to be sent to /login.
-app.config.errorHandler = (error, instance, info) => {
-  console.error('Vue runtime error:', error, info, instance)
+app.config.errorHandler = (error, _instance, info) => {
+  const message = error?.message || String(error || 'Unexpected application error')
+  const stack = error?.stack || ''
+
+  console.error('Vue runtime error:', message, info, stack)
   window.dispatchEvent(new CustomEvent('app-runtime-error', {
     detail: {
-      message: error?.message || 'Unexpected application error',
+      message,
       info
     }
   }))

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -1614,6 +1614,7 @@ const aiForm = ref({
     apiKey: "",
     url: "",
     model: "",
+    apiKeyConfigured: false,
 });
 
 const aiLoading = ref(false);
@@ -1642,6 +1643,7 @@ const cusipAiForm = ref({
     url: "",
     model: "",
     useMainProvider: true,
+    apiKeyConfigured: false,
 });
 
 const cusipAiLoading = ref(false);
@@ -1864,6 +1866,8 @@ const adminAiForm = ref({
     classifierApiKey: "",
     classifierUrl: "",
     classifierModel: "",
+    apiKeyConfigured: false,
+    classifierApiKeyConfigured: false,
 });
 const adminAiLoading = ref(false);
 
@@ -1874,6 +1878,7 @@ const adminCusipAiForm = ref({
     url: "",
     model: "",
     useMainProvider: true,
+    apiKeyConfigured: false,
 });
 const adminCusipAiLoading = ref(false);
 
@@ -1908,9 +1913,10 @@ async function loadAISettings() {
         const response = await api.get("/settings/ai-provider");
         aiForm.value = {
             provider: response.data.aiProvider || "",
-            apiKey: response.data.aiApiKey || "",
+            apiKey: "",
             url: response.data.aiApiUrl || "",
             model: response.data.aiModel || "",
+            apiKeyConfigured: response.data.aiApiKey === "***",
         };
     } catch (error) {
         console.error("Failed to load AI settings:", error);
@@ -1921,12 +1927,16 @@ async function loadAISettings() {
 async function updateAISettings() {
     aiLoading.value = true;
     try {
-        await api.put("/settings/ai-provider", {
+        const response = await api.put("/settings/ai-provider", {
             aiProvider: aiForm.value.provider,
-            aiApiKey: aiForm.value.apiKey,
+            aiApiKey:
+                aiForm.value.apiKey ||
+                (aiForm.value.apiKeyConfigured ? "***" : ""),
             aiApiUrl: aiForm.value.url,
             aiModel: aiForm.value.model,
         });
+        aiForm.value.apiKey = "";
+        aiForm.value.apiKeyConfigured = response.data.aiApiKey === "***";
         showSuccess("Success", "AI provider settings updated successfully");
     } catch (error) {
         console.error("Failed to update AI settings:", error);
@@ -1945,10 +1955,11 @@ async function loadCusipAISettings() {
         const response = await api.get("/settings/cusip-ai-provider");
         cusipAiForm.value = {
             provider: response.data.cusipAiProvider || "",
-            apiKey: response.data.cusipAiApiKey || "",
+            apiKey: "",
             url: response.data.cusipAiApiUrl || "",
             model: response.data.cusipAiModel || "",
             useMainProvider: response.data.useMainProvider !== false,
+            apiKeyConfigured: response.data.cusipAiApiKey === "***",
         };
     } catch (error) {
         console.error("Failed to load CUSIP AI settings:", error);
@@ -1958,13 +1969,18 @@ async function loadCusipAISettings() {
 async function updateCusipAISettings() {
     cusipAiLoading.value = true;
     try {
-        await api.put("/settings/cusip-ai-provider", {
+        const response = await api.put("/settings/cusip-ai-provider", {
             cusipAiProvider: cusipAiForm.value.provider,
-            cusipAiApiKey: cusipAiForm.value.apiKey,
+            cusipAiApiKey:
+                cusipAiForm.value.apiKey ||
+                (cusipAiForm.value.apiKeyConfigured ? "***" : ""),
             cusipAiApiUrl: cusipAiForm.value.url,
             cusipAiModel: cusipAiForm.value.model,
             useMainProvider: cusipAiForm.value.useMainProvider,
         });
+        cusipAiForm.value.apiKey = "";
+        cusipAiForm.value.apiKeyConfigured =
+            response.data.cusipAiApiKey === "***";
         showSuccess(
             "Success",
             "CUSIP AI provider settings updated successfully",
@@ -2400,14 +2416,17 @@ async function fetchAdminAISettings() {
         const response = await api.get("/settings/admin/ai");
         adminAiForm.value = {
             provider: response.data.aiProvider || "",
-            apiKey: response.data.aiApiKey || "",
+            apiKey: "",
             url: response.data.aiApiUrl || "",
             model: response.data.aiModel || "",
             classifierEnabled: response.data.aiClassifierEnabled === true,
             classifierProvider: response.data.aiClassifierProvider || "",
-            classifierApiKey: response.data.aiClassifierApiKey || "",
+            classifierApiKey: "",
             classifierUrl: response.data.aiClassifierApiUrl || "",
             classifierModel: response.data.aiClassifierModel || "",
+            apiKeyConfigured: response.data.aiApiKey === "***",
+            classifierApiKeyConfigured:
+                response.data.aiClassifierApiKey === "***",
         };
     } catch (error) {
         console.error("Failed to fetch admin AI settings:", error);
@@ -2418,17 +2437,26 @@ async function fetchAdminAISettings() {
 async function updateAdminAISettings() {
     adminAiLoading.value = true;
     try {
-        await api.put("/settings/admin/ai", {
+        const response = await api.put("/settings/admin/ai", {
             aiProvider: adminAiForm.value.provider,
-            aiApiKey: adminAiForm.value.apiKey,
+            aiApiKey:
+                adminAiForm.value.apiKey ||
+                (adminAiForm.value.apiKeyConfigured ? "***" : ""),
             aiApiUrl: adminAiForm.value.url,
             aiModel: adminAiForm.value.model,
             aiClassifierEnabled: adminAiForm.value.classifierEnabled,
             aiClassifierProvider: adminAiForm.value.classifierProvider,
-            aiClassifierApiKey: adminAiForm.value.classifierApiKey,
+            aiClassifierApiKey:
+                adminAiForm.value.classifierApiKey ||
+                (adminAiForm.value.classifierApiKeyConfigured ? "***" : ""),
             aiClassifierApiUrl: adminAiForm.value.classifierUrl,
             aiClassifierModel: adminAiForm.value.classifierModel,
         });
+        adminAiForm.value.apiKey = "";
+        adminAiForm.value.classifierApiKey = "";
+        adminAiForm.value.apiKeyConfigured = response.data.aiApiKey === "***";
+        adminAiForm.value.classifierApiKeyConfigured =
+            response.data.aiClassifierApiKey === "***";
         showSuccess(
             "Success",
             "Admin AI provider settings updated successfully",
@@ -2450,10 +2478,11 @@ async function fetchAdminCusipAISettings() {
         const response = await api.get("/settings/admin/cusip-ai");
         adminCusipAiForm.value = {
             provider: response.data.cusipAiProvider || "",
-            apiKey: response.data.cusipAiApiKey || "",
+            apiKey: "",
             url: response.data.cusipAiApiUrl || "",
             model: response.data.cusipAiModel || "",
             useMainProvider: response.data.useMainProvider !== false,
+            apiKeyConfigured: response.data.cusipAiApiKey === "***",
         };
     } catch (error) {
         console.error("Failed to fetch admin CUSIP AI settings:", error);
@@ -2463,13 +2492,18 @@ async function fetchAdminCusipAISettings() {
 async function updateAdminCusipAISettings() {
     adminCusipAiLoading.value = true;
     try {
-        await api.put("/settings/admin/cusip-ai", {
+        const response = await api.put("/settings/admin/cusip-ai", {
             cusipAiProvider: adminCusipAiForm.value.provider,
-            cusipAiApiKey: adminCusipAiForm.value.apiKey,
+            cusipAiApiKey:
+                adminCusipAiForm.value.apiKey ||
+                (adminCusipAiForm.value.apiKeyConfigured ? "***" : ""),
             cusipAiApiUrl: adminCusipAiForm.value.url,
             cusipAiModel: adminCusipAiForm.value.model,
             useMainProvider: adminCusipAiForm.value.useMainProvider,
         });
+        adminCusipAiForm.value.apiKey = "";
+        adminCusipAiForm.value.apiKeyConfigured =
+            response.data.cusipAiApiKey === "***";
         showSuccess(
             "Success",
             "Admin CUSIP AI provider settings updated successfully",


### PR DESCRIPTION
## What changed

- preserve configured user and admin AI API keys when saving unrelated provider settings
- keep masked API-key sentinels out of password inputs and track configured state explicitly
- improve saved-key placeholders and required-field behavior across the four AI settings forms
- improve Vue runtime-error logging
- add regression coverage for user/admin main and CUSIP key preservation

## Why

Masked API keys were being treated like editable input values. Saving a model-only change could overwrite or clear a previously configured secret, and required-field validation could incorrectly demand an already-saved key.

## Impact

Users and administrators can change provider models or URLs without re-entering saved credentials. Selecting a different provider still resets the configured-key state so a new credential can be supplied.

## Validation

- `corepack pnpm test -- --runInBand tests/controllers/settings.aiProviders.test.js` (10 tests passed)
- `corepack pnpm run build`
- `git diff --check`
