### PR TITLE
fix(charts): chart open trades, from a provider that serves candles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -139,7 +139,9 @@ FMP_RATE_LIMIT_PER_SECOND=5
 # Get an API key at: https://databento.com/ (signup includes free credits)
 DATABENTO_API_KEY=your_databento_api_key_here
 
-# Yahoo Finance - no-cost futures chart fallback when Databento is unavailable
+# Yahoo Finance - no-cost chart fallback for self-hosted instances, used for
+# equities and futures when the configured providers cannot serve candles.
+# Configured providers are always preferred; never used when billing is enabled.
 YAHOO_FINANCE_ENABLED=true
 
 # Alpha Vantage - For trade chart visualization (get free key at: https://www.alphavantage.co/support/#api-key)
@@ -149,6 +151,10 @@ YAHOO_FINANCE_ENABLED=true
 #   - Charts show daily candles, not intraday price action
 # This is sufficient for basic chart visualization on trade details
 ALPHA_VANTAGE_API_KEY=your_alpha_vantage_api_key_here
+# TIME_SERIES_INTRADAY is a premium Alpha Vantage endpoint. Leave disabled on a
+# free key: the attempt fails, is not cached, and still counts against the
+# 25-request daily allowance, so each chart load would spend two calls.
+ALPHA_VANTAGE_INTRADAY_ENABLED=false
 
 # OpenFIGI - For reliable CUSIP resolution (Bloomberg's free API - optional but recommended)
 # Get free API key at: https://www.openfigi.com/

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -152,8 +152,10 @@ FMP_RATE_LIMIT_PER_SECOND=5
 # Get a key at: https://databento.com/ (signup includes free credits)
 # DATABENTO_API_KEY=
 
-# Yahoo Finance - no-cost futures KLine fallback for self-hosted instances.
-# Configured market-data providers and Databento are always preferred.
+# Yahoo Finance - no-cost KLine fallback for self-hosted instances, used for
+# equities and futures when the configured providers cannot serve candles.
+# Configured market-data providers and Databento are always preferred, and
+# this fallback is never used when billing is enabled.
 # Set to false to disable this fallback.
 YAHOO_FINANCE_ENABLED=true
 
@@ -167,6 +169,10 @@ FINNHUB_RATE_LIMIT_PER_SECOND=1
 
 # Alpha Vantage - Historical chart data for trade visualization
 # Get a free API key at: https://www.alphavantage.co/
+# TIME_SERIES_INTRADAY is a premium Alpha Vantage endpoint. Leave disabled on a
+# free key: the attempt fails, is not cached, and still counts against the
+# 25-request daily allowance, so each chart load would spend two calls.
+ALPHA_VANTAGE_INTRADAY_ENABLED=false
 ALPHA_VANTAGE_API_KEY=
 
 # OpenFIGI - Alternative CUSIP/ISIN resolution

--- a/backend/src/services/chartService.js
+++ b/backend/src/services/chartService.js
@@ -210,7 +210,24 @@ class ChartService {
         return await finnhub.getTradeChartData(symbol, entryDate, exitDate, userId, resolution);
       }
 
-      // Self-hosted mode: configured provider preferred with Alpha Vantage fallback
+      // Self-hosted no-cost equity fallback, tried before Alpha Vantage because
+      // it needs no key, serves intraday, and has no daily request quota.
+      const yahooStockFallback = async (fallbackReason) => {
+        if (billingEnabled || !yahooFinance.isEnabled()) return null;
+        try {
+          const chartData = await yahooFinance.getStockTradeChartData(symbol, entryDate, exitDate, resolution);
+          if (fallbackReason) {
+            chartData.fallback = true;
+            chartData.fallback_reason = fallbackReason;
+          }
+          return chartData;
+        } catch (error) {
+          console.warn(`[CHART] Yahoo Finance unavailable for ${symbol}: ${error.message}`);
+          return null;
+        }
+      };
+
+      // Self-hosted mode: configured provider preferred with no-cost fallbacks
       if (isProUser && finnhub.isConfigured()) {
         console.log(`Using ${finnhub.displayName} for chart data (self-hosted)`);
         try {
@@ -218,14 +235,20 @@ class ChartService {
         } catch (error) {
           console.warn(`${finnhub.displayName} failed for symbol ${symbol}: ${error.message}`);
 
+          const yahooData = await yahooStockFallback(`${finnhub.displayName} unavailable: ${error.message}`);
+          if (yahooData) return yahooData;
+
           // Fall back to Alpha Vantage if configured
           if (alphaVantage.isConfigured()) {
             console.warn(`Falling back to Alpha Vantage due to ${finnhub.displayName} failure (${error.message})`);
             try {
-              const chartData = await alphaVantage.getTradeChartData(symbol, entryDate, exitDate);
+              const chartData = await alphaVantage.getTradeChartData(symbol, entryDate, exitDate, resolution);
               chartData.source = 'alphavantage';
               chartData.fallback = true;
-              chartData.fallbackReason = `${finnhub.displayName} unavailable`;
+              // Carry the provider's own message. Without it a persistently
+              // broken primary provider is indistinguishable from a healthy
+              // one, because every chart still renders from the fallback.
+              chartData.fallback_reason = `${finnhub.displayName} unavailable: ${error.message}`;
               return chartData;
             } catch (avError) {
               console.error(`Alpha Vantage fallback also failed for ${symbol}: ${avError.message}`);
@@ -240,16 +263,20 @@ class ChartService {
         }
       }
 
+      // Self-hosted: no configured provider — Yahoo first, then Alpha Vantage.
+      const yahooOnly = await yahooStockFallback(null);
+      if (yahooOnly) return yahooOnly;
+
       // Self-hosted: Finnhub not configured, use Alpha Vantage
       if (alphaVantage.isConfigured()) {
         console.log('Using Alpha Vantage for chart data (self-hosted)');
-        const chartData = await alphaVantage.getTradeChartData(symbol, entryDate, exitDate);
+        const chartData = await alphaVantage.getTradeChartData(symbol, entryDate, exitDate, resolution);
         chartData.source = 'alphavantage';
         return chartData;
       }
 
-      // Neither service is configured
-      throw new Error(`No chart data provider is configured. Please configure ${finnhub.providerName === 'fmp' ? 'FMP' : 'Finnhub'} or Alpha Vantage API keys.`);
+      // Nothing could serve the chart
+      throw new Error(`No chart data provider could serve ${symbol}. Configure ${finnhub.providerName === 'fmp' ? 'FMP' : 'Finnhub'} or Alpha Vantage API keys, or enable the Yahoo Finance fallback.`);
 
     } catch (error) {
       console.error(`Failed to get chart data for ${symbol}:`, error);
@@ -276,7 +303,7 @@ class ChartService {
     if (!billingEnabled) {
       status.alphaVantage = {
         configured: alphaVantage.isConfigured(),
-        description: 'Alpha Vantage API - Daily chart data (self-hosted fallback)'
+        description: 'Alpha Vantage API - Daily chart data (self-hosted fallback); intraday requires a premium key and ALPHA_VANTAGE_INTRADAY_ENABLED=true'
       };
       status.databento = {
         configured: databento.isConfigured(),
@@ -284,7 +311,7 @@ class ChartService {
       };
       status.yahoo_finance = {
         configured: yahooFinance.isEnabled(),
-        description: 'Yahoo Finance - no-cost self-hosted futures chart fallback'
+        description: 'Yahoo Finance - no-cost self-hosted chart fallback for equities and futures'
       };
     }
 

--- a/backend/src/utils/alphaVantage.js
+++ b/backend/src/utils/alphaVantage.js
@@ -6,6 +6,102 @@ const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const TRADE_CHART_CONTEXT_DAYS_BEFORE = 180;
 const TRADE_CHART_CONTEXT_DAYS_AFTER = 30;
 
+const ET_TIME_ZONE = 'America/New_York';
+
+// Resolutions the chart UI can request, mapped to Alpha Vantage intervals.
+const RESOLUTION_TO_INTRADAY_INTERVAL = {
+  '1': '1min',
+  '5': '5min',
+  '15': '15min',
+  '60': '60min'
+};
+
+// The interval labels the frontend understands (see intervalToPeriod).
+const INTRADAY_INTERVAL_LABEL = {
+  '1min': '1min',
+  '5min': '5min',
+  '15min': '15min',
+  '60min': '1hour'
+};
+
+const ALL_RESOLUTIONS = ['1', '5', '15', '60', 'D'];
+const DAILY_ONLY_RESOLUTIONS = ['D'];
+
+// Alpha Vantage serves roughly the trailing month of intraday history without a
+// premium plan, so only recent trades can be charted below daily.
+const INTRADAY_HISTORY_DAYS = 30;
+
+// Context to keep either side of the trade, per interval. A one minute chart
+// padded by whole days would bury the executions in thousands of bars.
+const INTRADAY_CONTEXT_MS = {
+  '1min': 90 * 60 * 1000,
+  '5min': 6 * 60 * 60 * 1000,
+  '15min': ONE_DAY_MS,
+  '60min': 5 * ONE_DAY_MS
+};
+
+// Offset of `timeZone` from UTC at `date`, in milliseconds.
+function zonedOffsetMs(timeZone, date) {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit'
+  });
+
+  const parts = {};
+  for (const part of formatter.formatToParts(date)) {
+    if (part.type !== 'literal') parts[part.type] = part.value;
+  }
+
+  const asUTC = Date.UTC(
+    Number(parts.year),
+    Number(parts.month) - 1,
+    Number(parts.day),
+    Number(parts.hour) % 24,
+    Number(parts.minute),
+    Number(parts.second)
+  );
+
+  return asUTC - date.getTime();
+}
+
+// Alpha Vantage returns intraday stamps as US/Eastern wall clock with no offset
+// ("2026-08-17 15:35:00"). Handing that to `new Date()` reinterprets it in the
+// container's own zone, shifting every bar by the UTC offset and pushing the
+// execution markers onto the wrong candles.
+function easternTimestampToEpochSeconds(value) {
+  const match = String(value).trim().match(/^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2})(?::(\d{2}))?$/);
+  if (!match) {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? Math.floor(parsed / 1000) : null;
+  }
+
+  const [, year, month, day, hour, minute, second] = match;
+  const utcGuess = Date.UTC(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hour),
+    Number(minute),
+    Number(second || 0)
+  );
+
+  // Resolve the offset twice. The first lookup uses the wall-clock reading as
+  // if it were UTC, which lands on the wrong side of a DST transition during
+  // the switch; re-resolving at the candidate instant corrects it.
+  const firstOffset = zonedOffsetMs(ET_TIME_ZONE, new Date(utcGuess));
+  const candidate = utcGuess - firstOffset;
+  const secondOffset = zonedOffsetMs(ET_TIME_ZONE, new Date(candidate));
+  const epochMs = secondOffset === firstOffset ? candidate : utcGuess - secondOffset;
+
+  return Math.floor(epochMs / 1000);
+}
+
 function candleRangeCoversDate(candles, targetDate) {
   if (!Array.isArray(candles) || candles.length === 0 || Number.isNaN(targetDate.getTime())) {
     return false;
@@ -130,7 +226,9 @@ class AlphaVantageClient {
 
   async getIntradayData(symbol, interval = '5min') {
     const symbolUpper = symbol.toUpperCase();
-    const cacheKey = `${symbolUpper}_${interval}`;
+    // v2: timestamps below are parsed as US/Eastern rather than container-local,
+    // so entries cached by an older build must not be reused.
+    const cacheKey = `${symbolUpper}_${interval}_v2`;
     
     // Check cache first
     const cached = await cache.get('chart_intraday', cacheKey);
@@ -160,13 +258,15 @@ class AlphaVantageClient {
 
       // Convert to array format for easier processing
       const candles = Object.entries(timeSeries).map(([time, values]) => ({
-        time: new Date(time).getTime() / 1000, // Convert to Unix timestamp
+        time: easternTimestampToEpochSeconds(time),
         open: parseFloat(values['1. open']),
         high: parseFloat(values['2. high']),
         low: parseFloat(values['3. low']),
         close: parseFloat(values['4. close']),
         volume: parseInt(values['5. volume'])
-      })).reverse(); // Reverse to get chronological order
+      }))
+        .filter((candle) => Number.isFinite(candle.time))
+        .sort((left, right) => left.time - right.time);
 
       // Cache the result
       await cache.set('chart_intraday', cacheKey, candles);
@@ -233,12 +333,91 @@ class AlphaVantageClient {
     }
   }
 
-  // Get chart data using daily data only (free tier compatible)
-  // Note: Intraday data (TIME_SERIES_INTRADAY) requires Alpha Vantage premium subscription
-  async getTradeChartData(symbol, entryDate, exitDate = null) {
+  // Intraday is opt-in because the endpoint is premium. Off by default, a free
+  // key never spends two tracked calls (a doomed intraday attempt, which is not
+  // cached, then the daily fallback) on a single chart load.
+  intradayEnabled() {
+    return String(process.env.ALPHA_VANTAGE_INTRADAY_ENABLED || '').trim().toLowerCase() === 'true';
+  }
+
+  // True when Alpha Vantage's trailing intraday history can still reach the trade.
+  intradayCoversTrade(entryTime) {
+    return Date.now() - entryTime.getTime() <= INTRADAY_HISTORY_DAYS * ONE_DAY_MS;
+  }
+
+  // Intraday chart data around a trade. TIME_SERIES_INTRADAY is a PREMIUM
+  // endpoint: a free key answers it with an "Information" notice rather than a
+  // series, and the attempt still counts against the tracked daily allowance.
+  // Reaching this method therefore requires ALPHA_VANTAGE_INTRADAY_ENABLED.
+  async getIntradayTradeChartData(symbol, entryTime, exitTime, interval) {
+    const candles = await this.getIntradayData(symbol, interval);
+
+    if (!Array.isArray(candles) || candles.length === 0) {
+      throw new Error(`No Alpha Vantage ${interval} candles were returned for ${symbol}.`);
+    }
+
+    const entrySeconds = Math.floor(entryTime.getTime() / 1000);
+    if (entrySeconds < candles[0].time) {
+      throw new Error(
+        `Alpha Vantage ${interval} history for ${symbol} begins after this trade's entry. ` +
+        'Intraday candles are only retained for about a month.'
+      );
+    }
+
+    const context = INTRADAY_CONTEXT_MS[interval] ?? ONE_DAY_MS;
+    const windowStart = Math.floor((entryTime.getTime() - context) / 1000);
+    const windowEnd = Math.floor((exitTime.getTime() + context) / 1000);
+    const filteredCandles = candles.filter((candle) => candle.time >= windowStart && candle.time <= windowEnd);
+
+    if (filteredCandles.length === 0) {
+      throw new Error(`No Alpha Vantage ${interval} candles fall inside the ${symbol} trade window.`);
+    }
+
+    console.log(`Filtered ${interval} candles: ${filteredCandles.length} of ${candles.length} within trade window`);
+
+    return {
+      type: 'intraday',
+      interval: INTRADAY_INTERVAL_LABEL[interval] || interval,
+      candles: filteredCandles,
+      source: 'alphavantage',
+      available_resolutions: ALL_RESOLUTIONS
+    };
+  }
+
+  // Get chart data for a trade at the requested resolution, falling back to
+  // daily candles when intraday history cannot reach the trade.
+  async getTradeChartData(symbol, entryDate, exitDate = null, resolution = 'D') {
     const entryTime = new Date(entryDate);
     const exitTime = exitDate ? new Date(exitDate) : new Date();
     const tradeDuration = exitTime - entryTime;
+    const intradayInterval = RESOLUTION_TO_INTRADAY_INTERVAL[String(resolution)];
+    let intradayUnavailableReason = null;
+
+    if (intradayInterval && !this.intradayEnabled()) {
+      intradayUnavailableReason =
+        'Alpha Vantage intraday is a premium endpoint and is disabled; ' +
+        'set ALPHA_VANTAGE_INTRADAY_ENABLED=true if your key includes it.';
+    } else if (intradayInterval) {
+      if (this.intradayCoversTrade(entryTime)) {
+        try {
+          return await this.getIntradayTradeChartData(symbol, entryTime, exitTime, intradayInterval);
+        } catch (error) {
+          intradayUnavailableReason = error.message;
+          console.warn(`Alpha Vantage intraday unavailable for ${symbol} (${intradayInterval}): ${error.message}`);
+        }
+      } else {
+        intradayUnavailableReason =
+          `Alpha Vantage keeps about ${INTRADAY_HISTORY_DAYS} days of intraday history; ` +
+          'this trade is older than that, so only daily candles are available.';
+      }
+    }
+
+    // Advertise intraday only when it could actually be served, so the chart's
+    // resolution buttons never silently do nothing.
+    const availableResolutions =
+      this.intradayEnabled() && intradayUnavailableReason === null && this.intradayCoversTrade(entryTime)
+        ? ALL_RESOLUTIONS
+        : DAILY_ONLY_RESOLUTIONS;
 
     console.log(`Alpha Vantage chart request - Symbol: ${symbol}, Entry: ${entryTime.toISOString()}, Exit: ${exitTime.toISOString()}, Duration: ${Math.ceil(tradeDuration / ONE_DAY_MS)} days`);
 
@@ -264,7 +443,9 @@ class AlphaVantageClient {
               type: 'daily',
               interval: 'daily',
               candles: cachedCandles,
-              source: 'alphavantage_cache'
+              source: 'alphavantage_cache',
+              available_resolutions: availableResolutions,
+              intraday_unavailable_reason: intradayUnavailableReason
             };
           }
         }
@@ -305,7 +486,9 @@ class AlphaVantageClient {
         type: 'daily',
         interval: 'daily',
         candles: filteredCandles,
-        source: 'alphavantage'
+        source: 'alphavantage',
+        available_resolutions: availableResolutions,
+        intraday_unavailable_reason: intradayUnavailableReason
       };
     } catch (error) {
       console.error(`Error fetching Alpha Vantage chart data for ${symbol}:`, error);

--- a/backend/src/utils/cache.js
+++ b/backend/src/utils/cache.js
@@ -45,7 +45,9 @@ const NAMESPACE_TTLS = {
   stock_splits: DAY,
   analyst_estimates: DAY,
   chart_intraday: 15 * MINUTE,
-  chart_daily: HOUR
+  chart_daily: HOUR,
+  yahoo_chart_intraday: 15 * MINUTE,
+  yahoo_chart_daily: HOUR
 };
 
 const SWEEP_INTERVAL_MS = MINUTE;

--- a/backend/src/utils/yahooFinance.js
+++ b/backend/src/utils/yahooFinance.js
@@ -1,8 +1,31 @@
 const axios = require('axios');
+const cache = require('./cache');
 const { getFuturesPointValue, getFuturesTickSize } = require('./futuresUtils');
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const YAHOO_CHART_HOSTS = ['query1.finance.yahoo.com', 'query2.finance.yahoo.com'];
+
+// Index underlyings are quoted with a caret on Yahoo. Without this an option on
+// XSP resolves to an unrelated ECN quote that returns zero bars.
+const INDEX_SYMBOLS = {
+  XSP: '^XSP',
+  SPX: '^SPX',
+  NDX: '^NDX',
+  RUT: '^RUT',
+  VIX: '^VIX',
+  DJX: '^DJI',
+  OEX: '^OEX'
+};
+
+// Yahoo suffixes an exchange after a dot (ISLN.L, BMW.DE) but writes share
+// classes with a dash (BRK-B). Both look like "TICKER.X", so the suffix has to
+// be checked against the exchange list before rewriting the separator.
+const EXCHANGE_SUFFIXES = new Set([
+  'L', 'DE', 'F', 'SG', 'MU', 'BE', 'DU', 'HM', 'HA', 'PA', 'AS', 'BR', 'LS', 'MI',
+  'MC', 'SW', 'VI', 'ST', 'HE', 'CO', 'OL', 'IC', 'IR', 'AT', 'WA', 'PR', 'BD',
+  'RG', 'VS', 'TL', 'TO', 'V', 'NE', 'CN', 'MX', 'SA', 'BA', 'SN', 'HK', 'SS',
+  'SZ', 'T', 'KS', 'KQ', 'TW', 'TWO', 'NS', 'BO', 'AX', 'NZ', 'SI', 'JO', 'TA', 'IS'
+]);
 const RETRYABLE_NETWORK_CODES = new Set([
   'EAI_AGAIN', 'ENOTFOUND', 'ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'ECONNABORTED'
 ]);
@@ -13,6 +36,26 @@ const RESOLUTIONS = {
   '15': { yahoo_interval: '15m', interval: '15min' },
   '60': { yahoo_interval: '60m', interval: '1hour' },
   D: { yahoo_interval: '1d', interval: 'daily' }
+};
+
+// Context to keep either side of an equity trade, per resolution.
+const INTRADAY_CONTEXT_MS = {
+  '1': 2 * 60 * 60 * 1000,
+  '5': 8 * 60 * 60 * 1000,
+  '15': DAY_MS,
+  '60': 3 * DAY_MS
+};
+
+const STOCK_DAILY_CONTEXT_DAYS_BEFORE = 180;
+const STOCK_DAILY_CONTEXT_DAYS_AFTER = 30;
+
+// Beyond these holding periods a resolution stops being readable (and asks
+// Yahoo for more bars than it will return in one response).
+const MAX_SPAN_MS = {
+  '1': 5 * DAY_MS,
+  '5': 40 * DAY_MS,
+  '15': 40 * DAY_MS,
+  '60': 300 * DAY_MS
 };
 
 function toDate(value) {
@@ -41,6 +84,23 @@ class YahooFinanceClient {
     return process.env.YAHOO_FINANCE_ENABLED !== 'false';
   }
 
+  // Translate a ledger symbol into the ticker Yahoo actually serves.
+  getYahooSymbol(symbol) {
+    const raw = String(symbol || '').trim().toUpperCase();
+    if (!raw) return raw;
+    if (raw.startsWith('^')) return raw;
+    if (INDEX_SYMBOLS[raw]) return INDEX_SYMBOLS[raw];
+
+    const lastDot = raw.lastIndexOf('.');
+    if (lastDot === -1) return raw;
+
+    const suffix = raw.slice(lastDot + 1);
+    if (EXCHANGE_SUFFIXES.has(suffix)) return raw;
+
+    // A share class, not an exchange: BRK.B -> BRK-B.
+    return `${raw.slice(0, lastDot)}-${suffix}`;
+  }
+
   getContinuousSymbol(root) {
     return `${String(root).trim().toUpperCase()}=F`;
   }
@@ -62,10 +122,34 @@ class YahooFinanceClient {
     return 'D';
   }
 
-  chartWindow(entryDate, exitDate, resolution) {
+  chartWindow(entryDate, exitDate, resolution, options = {}) {
     const entryTime = toDate(entryDate);
     if (!entryTime) throw new Error('Trade is missing entry time information');
     const exitTime = toDate(exitDate) || entryTime;
+
+    // A daily equity chart needs enough history to show the setup that preceded
+    // the trade, matching the context the Alpha Vantage path already uses.
+    if (options.spanHoldingPeriod && resolution === 'D') {
+      return {
+        period1: Math.floor((entryTime.getTime() - STOCK_DAILY_CONTEXT_DAYS_BEFORE * DAY_MS) / 1000),
+        period2: Math.floor(Math.min(
+          Date.now(),
+          Math.max(entryTime.getTime(), exitTime.getTime()) + STOCK_DAILY_CONTEXT_DAYS_AFTER * DAY_MS
+        ) / 1000)
+      };
+    }
+
+    // An equity position can be held for days, so its intraday window has to
+    // reach the exit. The futures path keeps its single-session window.
+    if (options.spanHoldingPeriod && resolution !== 'D') {
+      const context = INTRADAY_CONTEXT_MS[resolution] ?? 12 * 60 * 60 * 1000;
+      const openTrade = !toDate(exitDate);
+      const end = openTrade ? Date.now() : exitTime.getTime() + context;
+      return {
+        period1: Math.floor((entryTime.getTime() - context) / 1000),
+        period2: Math.floor(Math.min(Date.now(), end) / 1000)
+      };
+    }
 
     if (resolution === 'D') {
       return {
@@ -82,11 +166,28 @@ class YahooFinanceClient {
     };
   }
 
-  async fetchCandles(yahooSymbol, entryDate, exitDate, resolution) {
+  async fetchCandles(yahooSymbol, entryDate, exitDate, resolution, options = {}) {
     const config = RESOLUTIONS[resolution];
-    const window = this.chartWindow(entryDate, exitDate, resolution);
+    const window = this.chartWindow(entryDate, exitDate, resolution, options);
     if (window.period2 <= window.period1) {
       throw new Error('Yahoo Finance chart window is not available yet');
+    }
+
+    // An open trade's window ends at "now", so the raw bounds would never
+    // repeat and the cache would never hit. Round them to the bucket the TTL
+    // already tolerates.
+    const namespace = resolution === 'D' ? 'yahoo_chart_daily' : 'yahoo_chart_intraday';
+    const bucketSeconds = resolution === 'D' ? 3600 : 900;
+    const cacheKey = [
+      yahooSymbol,
+      config.yahoo_interval,
+      Math.floor(window.period1 / bucketSeconds),
+      Math.floor(window.period2 / bucketSeconds)
+    ].join('_');
+
+    const cached = await cache.get(namespace, cacheKey);
+    if (cached) {
+      return cached;
     }
 
     let response;
@@ -132,8 +233,9 @@ class YahooFinanceClient {
     if (!result || providerError) {
       throw new Error(providerError?.description || `No Yahoo Finance data available for ${yahooSymbol}`);
     }
-    if (result.meta?.instrumentType && result.meta.instrumentType !== 'FUTURE') {
-      throw new Error(`${yahooSymbol} did not resolve to a futures instrument`);
+    const expectedInstrumentType = options.expectedInstrumentType || null;
+    if (expectedInstrumentType && result.meta?.instrumentType && result.meta.instrumentType !== expectedInstrumentType) {
+      throw new Error(`${yahooSymbol} did not resolve to a ${expectedInstrumentType.toLowerCase()} instrument`);
     }
 
     const timestamps = result.timestamp || [];
@@ -153,6 +255,8 @@ class YahooFinanceClient {
     if (!candles.length) {
       throw new Error(`No Yahoo Finance candles available for ${yahooSymbol}`);
     }
+
+    await cache.set(namespace, cacheKey, candles);
     return candles;
   }
 
@@ -169,14 +273,15 @@ class YahooFinanceClient {
       ? `${requestedResolution}-minute data is outside Yahoo Finance retention`
       : null;
     let candles;
+    const futuresOptions = { expectedInstrumentType: 'FUTURE' };
 
     try {
-      candles = await this.fetchCandles(yahooSymbol, entryDate, exitDate, resolution);
+      candles = await this.fetchCandles(yahooSymbol, entryDate, exitDate, resolution, futuresOptions);
     } catch (error) {
       if (resolution === 'D') throw error;
       fallbackReason = error.message;
       resolution = 'D';
-      candles = await this.fetchCandles(yahooSymbol, entryDate, exitDate, resolution);
+      candles = await this.fetchCandles(yahooSymbol, entryDate, exitDate, resolution, futuresOptions);
     }
 
     return {
@@ -192,6 +297,74 @@ class YahooFinanceClient {
       available_resolutions: this.availableResolutions(entryDate),
       fallback: resolution !== requestedResolution,
       fallback_reason: fallbackReason
+    };
+  }
+
+  // Resolution that suits both the age of the trade (Yahoo's retention) and
+  // how long it was held.
+  // Which resolutions an equity trade can ACTUALLY be served at. Age alone is
+  // not enough: a ten-day hold resolves a 1m request to 5m, so advertising 1m
+  // would leave a control enabled that can never be honoured. Every resolution
+  // is filtered through the same age and span rules the request path applies.
+  availableStockResolutions(entryDate, exitDate) {
+    const byAge = this.availableResolutions(entryDate);
+    const serveable = byAge.filter(
+      (resolution) => this.effectiveStockResolution(resolution, entryDate, exitDate) === resolution
+    );
+
+    // 'D' is always serveable and must never be filtered out of the list.
+    return serveable.includes('D') ? serveable : [...serveable, 'D'];
+  }
+
+  effectiveStockResolution(requestedResolution, entryDate, exitDate) {
+    let resolution = this.effectiveResolution(requestedResolution, entryDate);
+    if (resolution === 'D') return resolution;
+
+    const entryTime = toDate(entryDate);
+    const exitTime = toDate(exitDate) || new Date();
+    const span = Math.max(0, exitTime.getTime() - entryTime.getTime());
+
+    const order = ['1', '5', '15', '60'];
+    let index = order.indexOf(resolution);
+    while (index !== -1 && index < order.length && span > (MAX_SPAN_MS[order[index]] ?? Infinity)) {
+      index += 1;
+      resolution = order[index] || 'D';
+    }
+
+    return resolution;
+  }
+
+  async getStockTradeChartData(symbol, entryDate, exitDate = null, requestedResolution = 'D') {
+    if (!this.isEnabled()) {
+      throw new Error('Yahoo Finance fallback is disabled');
+    }
+
+    const yahooSymbol = this.getYahooSymbol(symbol);
+    let resolution = this.effectiveStockResolution(requestedResolution, entryDate, exitDate);
+    let downgradeReason = resolution !== requestedResolution
+      ? `Yahoo Finance does not retain ${RESOLUTIONS[requestedResolution]?.interval || requestedResolution} data for a trade this old or this long.`
+      : null;
+    let candles;
+
+    const options = { spanHoldingPeriod: true };
+
+    try {
+      candles = await this.fetchCandles(yahooSymbol, entryDate, exitDate, resolution, options);
+    } catch (error) {
+      if (resolution === 'D') throw error;
+      downgradeReason = error.message;
+      resolution = 'D';
+      candles = await this.fetchCandles(yahooSymbol, entryDate, exitDate, resolution, options);
+    }
+
+    return {
+      type: resolution === 'D' ? 'daily' : 'intraday',
+      interval: RESOLUTIONS[resolution].interval,
+      candles,
+      source: 'yahoo',
+      symbol: yahooSymbol,
+      available_resolutions: this.availableStockResolutions(entryDate, exitDate),
+      intraday_unavailable_reason: resolution === 'D' ? downgradeReason : null
     };
   }
 }

--- a/backend/tests/utils/alphaVantage.intraday.test.js
+++ b/backend/tests/utils/alphaVantage.intraday.test.js
@@ -1,0 +1,193 @@
+jest.mock('../../src/utils/cache', () => ({
+  get: jest.fn(async () => null),
+  set: jest.fn(async () => true),
+  getStats: jest.fn(async () => ({ memoryEntries: 0, databaseEntries: 0 }))
+}));
+
+jest.mock('../../src/utils/historicalPriceCache', () => ({
+  hasRange: jest.fn(async () => false),
+  getRange: jest.fn(async () => []),
+  insertCandles: jest.fn(async () => true)
+}));
+
+const alphaVantage = require('../../src/utils/alphaVantage');
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+// Alpha Vantage reports intraday stamps as US/Eastern wall clock, newest first.
+function intradayResponse(interval, startMs, count, stepMinutes) {
+  const formatter = new Intl.DateTimeFormat('sv-SE', {
+    timeZone: 'America/New_York',
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit'
+  });
+
+  const series = {};
+  for (let index = count - 1; index >= 0; index -= 1) {
+    const stamp = formatter.format(new Date(startMs + index * stepMinutes * 60 * 1000));
+    series[stamp] = {
+      '1. open': '87.00',
+      '2. high': '87.50',
+      '3. low': '86.50',
+      '4. close': '87.10',
+      '5. volume': '1000'
+    };
+  }
+
+  return { [`Time Series (${interval})`]: series };
+}
+
+function dailyCandles(startMs, count) {
+  return Array.from({ length: count }, (_, index) => ({
+    time: Math.floor((startMs + index * ONE_DAY_MS) / 1000),
+    open: 86,
+    high: 88,
+    low: 85,
+    close: 87,
+    volume: 5000
+  }));
+}
+
+describe('Alpha Vantage intraday trade charts', () => {
+  let originalIntraday;
+
+  beforeEach(() => {
+    originalIntraday = process.env.ALPHA_VANTAGE_INTRADAY_ENABLED;
+    // Intraday is premium and opt-in; these cases exercise the enabled path.
+    process.env.ALPHA_VANTAGE_INTRADAY_ENABLED = 'true';
+  });
+
+  afterEach(() => {
+    if (originalIntraday === undefined) delete process.env.ALPHA_VANTAGE_INTRADAY_ENABLED;
+    else process.env.ALPHA_VANTAGE_INTRADAY_ENABLED = originalIntraday;
+    jest.restoreAllMocks();
+  });
+
+  test('maps Eastern wall-clock stamps to the correct instants regardless of server timezone', async () => {
+    jest.spyOn(alphaVantage, 'makeRequest').mockResolvedValue({
+      'Time Series (5min)': {
+        '2026-08-17 15:35:00': {
+          '1. open': '86.90', '2. high': '87.00', '3. low': '86.80', '4. close': '86.95', '5. volume': '1000'
+        },
+        '2026-08-17 15:30:00': {
+          '1. open': '86.80', '2. high': '86.90', '3. low': '86.70', '4. close': '86.85', '5. volume': '900'
+        }
+      }
+    });
+
+    const candles = await alphaVantage.getIntradayData('KO', '5min');
+
+    // 15:35 EDT is 19:35Z, which is how the execution is recorded.
+    expect(candles.map((candle) => candle.time)).toEqual([
+      Date.parse('2026-08-17T19:30:00.000Z') / 1000,
+      Date.parse('2026-08-17T19:35:00.000Z') / 1000
+    ]);
+  });
+
+  test('serves intraday candles when the requested resolution is intraday', async () => {
+    const entryMs = Date.now() - 4 * ONE_DAY_MS;
+    jest.spyOn(alphaVantage, 'makeRequest').mockResolvedValue(
+      intradayResponse('5min', entryMs - 2 * 60 * 60 * 1000, 200, 5)
+    );
+
+    const result = await alphaVantage.getTradeChartData('KO', new Date(entryMs).toISOString(), null, '5');
+
+    expect(result.interval).toBe('5min');
+    expect(result.type).toBe('intraday');
+    expect(result.available_resolutions).toContain('5');
+    expect(result.candles.length).toBeGreaterThan(0);
+    expect(result.candles[0].time).toBeLessThanOrEqual(Math.floor(entryMs / 1000));
+  });
+
+  test('advertises daily only, with a reason, once intraday history cannot reach the trade', async () => {
+    const entryMs = Date.now() - 200 * ONE_DAY_MS;
+    jest.spyOn(alphaVantage, 'getDailyData').mockResolvedValue(dailyCandles(entryMs - 50 * ONE_DAY_MS, 100));
+
+    const result = await alphaVantage.getTradeChartData('KO', new Date(entryMs).toISOString(), null, '5');
+
+    expect(result.interval).toBe('daily');
+    expect(result.available_resolutions).toEqual(['D']);
+    expect(result.intraday_unavailable_reason).toMatch(/intraday/i);
+  });
+
+  test('degrades to daily and keeps the provider message when the intraday call fails', async () => {
+    const entryMs = Date.now() - 4 * ONE_DAY_MS;
+    jest.spyOn(alphaVantage, 'makeRequest').mockResolvedValue({ Information: 'premium endpoint' });
+    jest.spyOn(alphaVantage, 'getDailyData').mockResolvedValue(dailyCandles(Date.now() - 100 * ONE_DAY_MS, 100));
+
+    const result = await alphaVantage.getTradeChartData('KO', new Date(entryMs).toISOString(), null, '5');
+
+    expect(result.interval).toBe('daily');
+    expect(result.available_resolutions).toEqual(['D']);
+    expect(result.intraday_unavailable_reason).toBeTruthy();
+  });
+
+  test('daily requests are unaffected and still offer intraday for a recent trade', async () => {
+    const entryMs = Date.now() - 4 * ONE_DAY_MS;
+    jest.spyOn(alphaVantage, 'getDailyData').mockResolvedValue(dailyCandles(Date.now() - 100 * ONE_DAY_MS, 100));
+
+    const result = await alphaVantage.getTradeChartData('KO', new Date(entryMs).toISOString(), null, 'D');
+
+    expect(result.interval).toBe('daily');
+    expect(result.available_resolutions).toContain('5');
+    expect(result.intraday_unavailable_reason).toBeNull();
+  });
+});
+
+describe('Alpha Vantage intraday is opt-in', () => {
+  let originalIntraday;
+
+  beforeEach(() => {
+    originalIntraday = process.env.ALPHA_VANTAGE_INTRADAY_ENABLED;
+    delete process.env.ALPHA_VANTAGE_INTRADAY_ENABLED;
+  });
+
+  afterEach(() => {
+    if (originalIntraday === undefined) delete process.env.ALPHA_VANTAGE_INTRADAY_ENABLED;
+    else process.env.ALPHA_VANTAGE_INTRADAY_ENABLED = originalIntraday;
+    jest.restoreAllMocks();
+  });
+
+  test('spends no request on the premium endpoint when disabled', async () => {
+    const makeRequest = jest.spyOn(alphaVantage, 'makeRequest');
+    jest.spyOn(alphaVantage, 'getDailyData').mockResolvedValue(dailyCandles(Date.now() - 100 * ONE_DAY_MS, 100));
+
+    const result = await alphaVantage.getTradeChartData(
+      'KO', new Date(Date.now() - 4 * ONE_DAY_MS).toISOString(), null, '5'
+    );
+
+    // The doomed attempt is what burns the daily allowance twice over.
+    expect(makeRequest).not.toHaveBeenCalled();
+    expect(result.interval).toBe('daily');
+  });
+
+  test('does not advertise intraday when disabled', async () => {
+    jest.spyOn(alphaVantage, 'getDailyData').mockResolvedValue(dailyCandles(Date.now() - 100 * ONE_DAY_MS, 100));
+
+    const result = await alphaVantage.getTradeChartData(
+      'KO', new Date(Date.now() - 4 * ONE_DAY_MS).toISOString(), null, 'D'
+    );
+
+    expect(result.available_resolutions).toEqual(['D']);
+    // A daily request that returns daily is not a downgrade, so it needs no
+    // explanation; the reason belongs only where intraday was actually asked for.
+    expect(result.intraday_unavailable_reason).toBeNull();
+  });
+
+  test('explains the refusal when intraday IS requested while disabled', async () => {
+    jest.spyOn(alphaVantage, 'getDailyData').mockResolvedValue(dailyCandles(Date.now() - 100 * ONE_DAY_MS, 100));
+
+    const result = await alphaVantage.getTradeChartData(
+      'KO', new Date(Date.now() - 4 * ONE_DAY_MS).toISOString(), null, '5'
+    );
+
+    expect(result.intraday_unavailable_reason).toMatch(/premium/i);
+    expect(result.intraday_unavailable_reason).toMatch(/ALPHA_VANTAGE_INTRADAY_ENABLED/);
+  });
+});
+

--- a/backend/tests/utils/yahooFinance.stocks.test.js
+++ b/backend/tests/utils/yahooFinance.stocks.test.js
@@ -1,0 +1,191 @@
+jest.mock('axios', () => ({
+  get: jest.fn()
+}));
+
+jest.mock('../../src/utils/cache', () => ({
+  get: jest.fn(async () => null),
+  set: jest.fn(async () => true)
+}));
+
+const axios = require('axios');
+const yahooFinance = require('../../src/utils/yahooFinance');
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function equityResponse(startSeconds, count, stepSeconds, instrumentType = 'EQUITY') {
+  const timestamp = Array.from({ length: count }, (_, index) => startSeconds + index * stepSeconds);
+  return {
+    data: {
+      chart: {
+        error: null,
+        result: [{
+          meta: { symbol: 'MP', instrumentType, exchangeTimezoneName: 'America/New_York' },
+          timestamp,
+          indicators: {
+            quote: [{
+              open: timestamp.map(() => 60.4),
+              high: timestamp.map(() => 60.7),
+              low: timestamp.map(() => 60.2),
+              close: timestamp.map(() => 60.5),
+              volume: timestamp.map(() => 1000)
+            }]
+          }
+        }]
+      }
+    }
+  };
+}
+
+describe('Yahoo Finance equity charts', () => {
+  let originalEnabled;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    originalEnabled = process.env.YAHOO_FINANCE_ENABLED;
+    process.env.YAHOO_FINANCE_ENABLED = 'true';
+  });
+
+  afterEach(() => {
+    if (originalEnabled === undefined) delete process.env.YAHOO_FINANCE_ENABLED;
+    else process.env.YAHOO_FINANCE_ENABLED = originalEnabled;
+  });
+
+  test('serves intraday candles for a recent equity trade', async () => {
+    const entry = new Date(Date.now() - 4 * DAY_MS);
+    axios.get.mockResolvedValue(equityResponse(Math.floor(entry.getTime() / 1000) - 3600, 100, 300));
+
+    const result = await yahooFinance.getStockTradeChartData('MP', entry.toISOString(), null, '5');
+
+    expect(result.source).toBe('yahoo');
+    expect(result.interval).toBe('5min');
+    expect(result.type).toBe('intraday');
+    expect(result.candles).toHaveLength(100);
+  });
+
+  test('does not reject equities the way the futures path does', async () => {
+    const entry = new Date(Date.now() - 2 * DAY_MS);
+    axios.get.mockResolvedValue(equityResponse(Math.floor(entry.getTime() / 1000), 10, 300, 'EQUITY'));
+
+    await expect(
+      yahooFinance.getStockTradeChartData('MP', entry.toISOString(), null, '5')
+    ).resolves.toMatchObject({ source: 'yahoo' });
+  });
+
+  test('the futures path still requires a futures instrument', async () => {
+    axios.get.mockResolvedValue(equityResponse(1_700_000_000, 10, 300, 'EQUITY'));
+
+    await expect(
+      yahooFinance.getFuturesTradeChartData('ES', {
+        symbol: 'ESZ5',
+        entry_time: new Date(Date.now() - DAY_MS).toISOString(),
+        exit_time: null
+      }, '1')
+    ).rejects.toThrow(/did not resolve to a future/i);
+  });
+
+  test('degrades an old trade to daily rather than requesting absent intraday history', async () => {
+    const entry = new Date(Date.now() - 400 * DAY_MS);
+    axios.get.mockResolvedValue(equityResponse(Math.floor(entry.getTime() / 1000), 50, 86400));
+
+    const result = await yahooFinance.getStockTradeChartData('MP', entry.toISOString(), null, '5');
+
+    expect(result.interval).toBe('daily');
+    expect(result.available_resolutions).toEqual(['D']);
+  });
+
+  test('coarsens the resolution when the holding period is too long for it', async () => {
+    const entry = new Date(Date.now() - 25 * DAY_MS);
+    const exit = new Date(Date.now() - 2 * DAY_MS);
+    axios.get.mockResolvedValue(equityResponse(Math.floor(entry.getTime() / 1000), 50, 3600));
+
+    // 23 days held is far past what a 1-minute chart can show.
+    const result = await yahooFinance.getStockTradeChartData('MP', entry.toISOString(), exit.toISOString(), '1');
+
+    expect(result.interval).not.toBe('1min');
+  });
+
+  describe('symbol translation', () => {
+    test.each([
+      ['KO', 'KO'],
+      ['ISLN.L', 'ISLN.L'],
+      ['BMW.DE', 'BMW.DE'],
+      ['ZPRR.DE', 'ZPRR.DE'],
+      ['BRK.B', 'BRK-B'],
+      ['XSP', '^XSP'],
+      ['SPX', '^SPX'],
+      ['^VIX', '^VIX'],
+      ['ko', 'KO']
+    ])('%s resolves to %s', (input, expected) => {
+      expect(yahooFinance.getYahooSymbol(input)).toBe(expected);
+    });
+  });
+
+  test('requests the translated symbol, not the raw ledger one', async () => {
+    const entry = new Date(Date.now() - 2 * DAY_MS);
+    axios.get.mockResolvedValue(equityResponse(Math.floor(entry.getTime() / 1000), 10, 300));
+
+    await yahooFinance.getStockTradeChartData('XSP', entry.toISOString(), null, '5');
+
+    expect(axios.get.mock.calls[0][0]).toContain(encodeURIComponent('^XSP'));
+  });
+
+  test('a daily equity window carries months of prior context', async () => {
+    const entry = new Date(Date.now() - 10 * DAY_MS);
+    axios.get.mockResolvedValue(equityResponse(Math.floor(entry.getTime() / 1000), 50, 86400));
+
+    await yahooFinance.getStockTradeChartData('MP', entry.toISOString(), null, 'D');
+
+    const { params } = axios.get.mock.calls[0][1];
+    const contextDays = (entry.getTime() / 1000 - params.period1) / (24 * 60 * 60);
+    expect(contextDays).toBeGreaterThan(150);
+  });
+});
+
+describe('advertised resolutions match what can be served', () => {
+  let originalEnabled;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    originalEnabled = process.env.YAHOO_FINANCE_ENABLED;
+    process.env.YAHOO_FINANCE_ENABLED = 'true';
+  });
+
+  afterEach(() => {
+    if (originalEnabled === undefined) delete process.env.YAHOO_FINANCE_ENABLED;
+    else process.env.YAHOO_FINANCE_ENABLED = originalEnabled;
+  });
+
+  test('a long hold does not advertise a resolution the span rules would coarsen', () => {
+    // Recent enough for 1m by age, but held far longer than a 1m chart can show.
+    const entry = new Date(Date.now() - 12 * DAY_MS).toISOString();
+    const exit = new Date(Date.now() - DAY_MS).toISOString();
+
+    const advertised = yahooFinance.availableStockResolutions(entry, exit);
+
+    expect(yahooFinance.effectiveStockResolution('1', entry, exit)).not.toBe('1');
+    expect(advertised).not.toContain('1');
+    expect(advertised).toContain('D');
+  });
+
+  test('every advertised resolution survives the request path unchanged', () => {
+    const cases = [
+      [new Date(Date.now() - 2 * DAY_MS).toISOString(), null],
+      [new Date(Date.now() - 12 * DAY_MS).toISOString(), new Date(Date.now() - DAY_MS).toISOString()],
+      [new Date(Date.now() - 200 * DAY_MS).toISOString(), null]
+    ];
+
+    for (const [entry, exit] of cases) {
+      for (const resolution of yahooFinance.availableStockResolutions(entry, exit)) {
+        expect(yahooFinance.effectiveStockResolution(resolution, entry, exit)).toBe(resolution);
+      }
+    }
+  });
+
+  test('a short scalp still advertises the fine resolutions', () => {
+    const entry = new Date(Date.now() - 2 * DAY_MS).toISOString();
+    const exit = new Date(Date.parse(entry) + 5 * 60 * 1000).toISOString();
+
+    expect(yahooFinance.availableStockResolutions(entry, exit)).toContain('1');
+  });
+});
+

--- a/backend/tests/utils/yahooFinance.test.js
+++ b/backend/tests/utils/yahooFinance.test.js
@@ -2,6 +2,13 @@ jest.mock('axios', () => ({
   get: jest.fn()
 }));
 
+// Chart responses are cached, so these network-behaviour tests have to opt out
+// or a previous test's candles would satisfy the request under test.
+jest.mock('../../src/utils/cache', () => ({
+  get: jest.fn(async () => null),
+  set: jest.fn(async () => true)
+}));
+
 const axios = require('axios');
 const yahooFinance = require('../../src/utils/yahooFinance');
 

--- a/frontend/src/components/trades/KLineTradeChart.vue
+++ b/frontend/src/components/trades/KLineTradeChart.vue
@@ -124,6 +124,7 @@ import {
   formatSignedChartCurrency,
   formatSignedChartPercent,
 } from '@/utils/chartPnlMeasurement'
+import { clipBandToPane } from '@/utils/chartPositionBands'
 
 const props = defineProps({
   chartData: {
@@ -410,12 +411,19 @@ function registerPositionOverlay() {
       const entryY = yAxis.convertToPixel(entryPrice)
       const stopY = yAxis.convertToPixel(stopLoss)
       const targetY = yAxis.convertToPixel(takeProfit)
-      const profitTop = Math.min(entryY, targetY)
-      const riskTop = Math.min(entryY, stopY)
-      return [
-        {
+
+      // At intraday resolutions the visible bars often exclude the stop and the
+      // target, so these pixel positions land far outside the pane. Clip each
+      // band to it instead of drawing an unbounded rectangle.
+      const rewardBand = clipBandToPane(entryY, targetY, bounding.height)
+      const riskBand = clipBandToPane(entryY, stopY, bounding.height)
+
+      const figures = []
+
+      if (rewardBand) {
+        figures.push({
           type: 'rect',
-          attrs: { x: left, y: profitTop, width, height: Math.max(1, Math.abs(targetY - entryY)) },
+          attrs: { x: left, y: rewardBand.y, width, height: rewardBand.height },
           styles: {
             style: 'stroke_fill',
             color: 'rgba(5, 150, 105, 0.14)',
@@ -424,10 +432,13 @@ function registerPositionOverlay() {
             borderStyle: 'solid',
           },
           ignoreEvent: true,
-        },
-        {
+        })
+      }
+
+      if (riskBand) {
+        figures.push({
           type: 'rect',
-          attrs: { x: left, y: riskTop, width, height: Math.max(1, Math.abs(stopY - entryY)) },
+          attrs: { x: left, y: riskBand.y, width, height: riskBand.height },
           styles: {
             style: 'stroke_fill',
             color: 'rgba(220, 38, 38, 0.12)',
@@ -436,14 +447,19 @@ function registerPositionOverlay() {
             borderStyle: 'solid',
           },
           ignoreEvent: true,
-        },
-        {
+        })
+      }
+
+      if (Number.isFinite(entryY) && entryY >= 0 && entryY <= bounding.height) {
+        figures.push({
           type: 'line',
           attrs: { coordinates: [{ x: left, y: entryY }, { x: right, y: entryY }] },
           styles: { style: 'dashed', size: 1, color: '#6b7280', dashedValue: [4, 3] },
           ignoreEvent: true,
-        },
-      ]
+        })
+      }
+
+      return figures
     },
   })
 

--- a/frontend/src/components/trades/TradeChartVisualization.vue
+++ b/frontend/src/components/trades/TradeChartVisualization.vue
@@ -21,8 +21,10 @@
           <span
             v-if="chartData.source"
             class="rounded-full bg-primary-100 px-2 py-1 text-xs font-medium text-primary-800 dark:bg-primary-900/40 dark:text-primary-200"
+            :class="{ 'cursor-help': sourceTitle }"
+            :title="sourceTitle"
           >
-            {{ sourceLabel }}
+            {{ sourceLabel }}<template v-if="sourceTitle"> ·  fallback</template>
           </span>
         </div>
       </div>
@@ -87,6 +89,13 @@
           Contract rollover can create differences from the recorded fill price.
         </div>
 
+        <div
+          v-if="degradationNotice"
+          class="mb-3 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-100"
+        >
+          {{ degradationNotice }}
+        </div>
+
         <KLineTradeChart
           :chart-data="chartData"
           :timezone="userTimezone || 'UTC'"
@@ -104,7 +113,7 @@
           </div>
           <div class="rounded-lg bg-gray-50 px-3 py-2 dark:bg-gray-800/70">
             <dt class="text-gray-500 dark:text-gray-400">Exit</dt>
-            <dd class="mt-0.5 font-semibold text-gray-900 dark:text-white">{{ formatCurrency(chartData.trade.exitPrice) }}</dd>
+            <dd class="mt-0.5 font-semibold text-gray-900 dark:text-white">{{ exitLabel }}</dd>
           </div>
           <div class="rounded-lg bg-gray-50 px-3 py-2 dark:bg-gray-800/70">
             <dt class="text-gray-500 dark:text-gray-400">P&amp;L</dt>
@@ -188,6 +197,27 @@ const intervalLabel = computed(() => {
   return labels[chartData.value?.interval] || `${chartData.value?.interval || 'Daily'} candles`
 })
 
+// An open trade has no exit yet; say so rather than formatting a null.
+const exitLabel = computed(() => {
+  const exitPrice = chartData.value?.trade?.exitPrice
+  if (exitPrice === null || exitPrice === undefined) return 'Open'
+  return formatCurrency(exitPrice)
+})
+
+// Surface a degraded chart instead of quietly rendering fallback data: a
+// permanently failing primary provider otherwise looks identical to a healthy
+// one, since a chart still appears either way.
+const degradationNotice = computed(() => chartData.value?.intraday_unavailable_reason || null)
+
+// The primary provider failing is often a permanent plan limitation rather than
+// an incident, so it belongs on the source chip rather than in a banner that
+// would nag on every chart.
+// snake_case is the convention the futures paths already use; camelCase is read
+// as well so a response from an older backend still explains itself.
+const sourceTitle = computed(
+  () => chartData.value?.fallback_reason ?? chartData.value?.fallbackReason ?? null
+)
+
 const sourceLabel = computed(() => {
   const labels = {
     finnhub: 'Finnhub',
@@ -208,6 +238,9 @@ function metricClass(value) {
 }
 
 function formatPercent(value) {
+  // Number(null) is 0, so an open trade would otherwise report a confident
+  // +0.00% return instead of admitting it has none yet.
+  if (value === null || value === undefined || value === '') return 'N/A'
   const number = Number(value)
   if (!Number.isFinite(number)) return 'N/A'
   return `${number >= 0 ? '+' : ''}${number.toFixed(2)}%`

--- a/frontend/src/utils/chartPositionBands.js
+++ b/frontend/src/utils/chartPositionBands.js
@@ -1,0 +1,24 @@
+// The risk and reward bands of the planned-position overlay are drawn between
+// price levels that are frequently outside the visible price range: a stop far
+// below the bars currently on screen, a target far above them. klinecharts
+// scales its y-axis to the *visible* candles, so `convertToPixel` happily
+// returns coordinates thousands of pixels outside the pane for those levels.
+// Drawing a rectangle straight from them makes the overlay appear to expand
+// without bound, which is why every band has to be clipped to the pane first.
+export function clipBandToPane(fromY, toY, paneHeight) {
+  if (![fromY, toY, paneHeight].every(Number.isFinite)) return null
+  if (paneHeight <= 0) return null
+
+  const top = Math.min(fromY, toY)
+  const bottom = Math.max(fromY, toY)
+
+  // Entirely above or entirely below the pane: nothing to draw.
+  if (bottom < 0 || top > paneHeight) return null
+
+  const clippedTop = Math.min(Math.max(top, 0), paneHeight)
+  const clippedBottom = Math.min(Math.max(bottom, 0), paneHeight)
+
+  // A band that is visible but degenerate still deserves a hairline, matching
+  // the previous behaviour for a stop or target sitting on the entry price.
+  return { y: clippedTop, height: Math.max(1, clippedBottom - clippedTop) }
+}

--- a/frontend/src/utils/chartPositionBands.test.js
+++ b/frontend/src/utils/chartPositionBands.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'vitest'
+import { clipBandToPane } from './chartPositionBands'
+
+const PANE = 400
+
+describe('clipBandToPane', () => {
+  test('leaves a band that fits inside the pane untouched', () => {
+    expect(clipBandToPane(120, 260, PANE)).toEqual({ y: 120, height: 140 })
+  })
+
+  test('clips a stop that sits far below the visible price range', () => {
+    // Entry on screen, stop 8000px below it — the 15m KO case.
+    expect(clipBandToPane(180, 8200, PANE)).toEqual({ y: 180, height: 220 })
+  })
+
+  test('clips a target far above the visible price range', () => {
+    expect(clipBandToPane(-5000, 210, PANE)).toEqual({ y: 0, height: 210 })
+  })
+
+  test('drops a band that lies entirely above the pane', () => {
+    expect(clipBandToPane(-900, -400, PANE)).toBeNull()
+  })
+
+  test('drops a band that lies entirely below the pane', () => {
+    expect(clipBandToPane(700, 1200, PANE)).toBeNull()
+  })
+
+  test('spans the pane when both levels are off opposite edges', () => {
+    expect(clipBandToPane(-2000, 3000, PANE)).toEqual({ y: 0, height: PANE })
+  })
+
+  test('keeps a hairline for a visible but degenerate band', () => {
+    expect(clipBandToPane(200, 200, PANE)).toEqual({ y: 200, height: 1 })
+  })
+
+  test('accepts reversed coordinates', () => {
+    expect(clipBandToPane(260, 120, PANE)).toEqual({ y: 120, height: 140 })
+  })
+
+  test('rejects non-finite coordinates rather than drawing NaN geometry', () => {
+    expect(clipBandToPane(Number.NaN, 200, PANE)).toBeNull()
+    expect(clipBandToPane(100, Number.POSITIVE_INFINITY, PANE)).toBeNull()
+    expect(clipBandToPane(100, 200, 0)).toBeNull()
+  })
+})

--- a/frontend/src/views/trades/TradeDetailView.vue
+++ b/frontend/src/views/trades/TradeDetailView.vue
@@ -1242,7 +1242,10 @@
           </div>
 
           <!-- Trade Chart Visualization (Collapsible) -->
-          <div v-if="trade.exit_price && trade.exit_time" class="card">
+          <!-- Open trades chart too: the endpoint returns candles up to the
+               present for them, and KLineTradeChart already renders an entry
+               marker with no exit. -->
+          <div v-if="trade.entry_time || trade.trade_date" class="card">
             <div class="card-body">
               <button
                 @click="toggleChartSection"
@@ -1707,6 +1710,7 @@ function hasLegacyFuturesExcursionUnits(currentTrade, captured, scale) {
 
 const loading = ref(true)
 const trade = ref(null)
+
 // True only for the trade's owner. Guests/other users viewing a public trade get
 // a read-only view: owner actions and owner-only data fetches are skipped.
 const isOwner = computed(() => !!authStore.user && !!trade.value && trade.value.user_id === authStore.user.id)


### PR DESCRIPTION
**What changed**
1. Yahoo equity charts — intraday plus 180 days of daily context, matching the context window the Alpha Vantage path already used. Resolution is coarsened by both trade age and holding period so we never request bars Yahoo doesn't retain.
2. Symbol translation — index underlyings need a caret (XSP → ^XSP, which otherwise matches an unrelated ECN quote returning zero bars) and share classes need a dash (BRK.B → BRK-B), while exchange suffixes like ISLN.L must be left alone.
3. Caching, with the window quantised so an open trade whose window ends at "now" still hits the cache instead of re-fetching on every load.
4. Resolution plumbed through to Alpha Vantage for anyone holding a premium key, and available_resolutions reported honestly so the controls disable rather than silently no-op.
5. Alpha Vantage timestamps parsed as US/Eastern. They were parsed with a bare new Date(), which reinterprets them in the container's timezone — on a UTC container every intraday bar shifts 4–5 hours, putting execution markers on the wrong candles. Now parsed explicitly and DST-correctly.
6. Open trades get a chart.
7. Overlay bands clipped to the pane. The planned-position overlay drew its risk/reward rectangles straight from yAxis.convertToPixel(). klinecharts scales the axis to the visible bars, so at 15m and finer the stop and target sit far outside it and the bands rendered thousands of pixels tall, bleeding across the chart.
8. Degraded charts say why — a provider plan limitation is usually permanent, so it sits on the source chip; an intraday downgrade, which explains disabled controls, gets a banner.
9. Two null-coercion fixes — an open trade reported a confident +0.00% return (Number(null) is 0, and only NaN was guarded) and a formatted null exit price.

**Testing**
1. New: alphaVantage.intraday.test.js, yahooFinance.stocks.test.js, chartPositionBands.test.js — including the exact 15m case where the stop sits ~8000px below the pane.
2. Generalising fetchCandles made the futures instrument guard opt-in, and a test caught that the futures path had stopped opting in — the guard is restored and now covered.
3. One existing test needed a cache mock added, since chart responses are now cached and a previous test's candles would otherwise satisfy the request under test.
4. Full suite green.

**Notes for review**
1. No schema changes, no new dependencies — yahooFinance.js, klinecharts and the Alpha Vantage client were all already present.
2. Behaviour on a hosted instance is unchanged: Yahoo is gated off, and the configured provider path is untouched.