### PR TITLE
fix(sessions): judge a fill by the hours of the venue it traded on

### DIFF
--- a/frontend/src/components/trades/TradeMarketSessionBadge.vue
+++ b/frontend/src/components/trades/TradeMarketSessionBadge.vue
@@ -26,7 +26,10 @@ const instrumentType = computed(() => String(
 
 const session = computed(() => {
   if (!['stock', 'option'].includes(instrumentType.value)) return null
-  return getTradeMarketSession(props.trade.entry_time ?? props.trade.entryTime)
+  return getTradeMarketSession(
+    props.trade.entry_time ?? props.trade.entryTime,
+    props.trade.symbol
+  )
 })
 
 const sessionClasses = computed(() => ({

--- a/frontend/src/utils/exchangeSessions.js
+++ b/frontend/src/utils/exchangeSessions.js
@@ -31,8 +31,44 @@ const EXCHANGES = {
   AX: { zone: 'Australia/Sydney', open: 10 * 60, close: 16 * 60, venue: 'ASX', tzLabel: 'Sydney' },
 }
 
+// A TradingView import keeps the exchange on the symbol (LSE:IGLN), stating the
+// venue outright instead of implying it with a suffix. US prefixes need no
+// entry here — NASDAQ:DEVS and NYSE:KO already land on the default.
+const EXCHANGE_PREFIXES = {
+  LSE: 'L',
+  XETR: 'DE',
+  FWB: 'F',
+  GETTEX: 'F',
+  TRADEGATE: 'F',
+  // One prefix covers the continental Euronext books. Paris, Amsterdam and
+  // Brussels share a session; Lisbon runs an hour earlier and is read an hour
+  // late here, which is still its own morning rather than New York's.
+  EURONEXT: 'PA',
+  MIL: 'MI',
+  BME: 'MC',
+  SIX: 'SW',
+  VIE: 'VI',
+  OMXSTO: 'ST',
+  OMXCOP: 'CO',
+  OMXHEX: 'HE',
+  OSL: 'OL',
+  TSX: 'TO',
+  HKEX: 'HK',
+  TSE: 'T',
+  ASX: 'AX',
+}
+
 export function exchangeForSymbol(symbol) {
-  const normalized = String(symbol || '').trim().toUpperCase()
+  let normalized = String(symbol || '').trim().toUpperCase()
+
+  const colon = normalized.indexOf(':')
+  if (colon !== -1) {
+    const prefix = EXCHANGE_PREFIXES[normalized.slice(0, colon)]
+    if (prefix) return EXCHANGES[prefix]
+    // Unrecognised: drop it and let any suffix on the rest still be read.
+    normalized = normalized.slice(colon + 1)
+  }
+
   const lastDot = normalized.lastIndexOf('.')
   if (lastDot === -1) return US
 

--- a/frontend/src/utils/exchangeSessions.js
+++ b/frontend/src/utils/exchangeSessions.js
@@ -1,0 +1,43 @@
+// Regular trading hours per listing venue, in the venue's own timezone.
+// Without this a trade is classified against New York hours wherever it was
+// executed, so a 14:26 London fill reads "Pre-market" because it happened
+// before 09:30 in a city it has nothing to do with.
+//
+// Keyed by the Yahoo-style suffix carried on the symbol; no suffix means a US
+// listing, which is the default.
+const US = { zone: 'America/New_York', open: 9 * 60 + 30, close: 16 * 60, venue: 'US', tzLabel: 'ET' }
+
+const EXCHANGES = {
+  L: { zone: 'Europe/London', open: 8 * 60, close: 16 * 60 + 30, venue: 'LSE', tzLabel: 'London' },
+  DE: { zone: 'Europe/Berlin', open: 9 * 60, close: 17 * 60 + 30, venue: 'XETRA', tzLabel: 'Frankfurt' },
+  F: { zone: 'Europe/Berlin', open: 8 * 60, close: 22 * 60, venue: 'Frankfurt', tzLabel: 'Frankfurt' },
+  PA: { zone: 'Europe/Paris', open: 9 * 60, close: 17 * 60 + 30, venue: 'Euronext Paris', tzLabel: 'Paris' },
+  AS: { zone: 'Europe/Amsterdam', open: 9 * 60, close: 17 * 60 + 30, venue: 'Euronext Amsterdam', tzLabel: 'Amsterdam' },
+  BR: { zone: 'Europe/Brussels', open: 9 * 60, close: 17 * 60 + 30, venue: 'Euronext Brussels', tzLabel: 'Brussels' },
+  LS: { zone: 'Europe/Lisbon', open: 8 * 60, close: 16 * 60 + 30, venue: 'Euronext Lisbon', tzLabel: 'Lisbon' },
+  MI: { zone: 'Europe/Rome', open: 9 * 60, close: 17 * 60 + 30, venue: 'Borsa Italiana', tzLabel: 'Milan' },
+  MC: { zone: 'Europe/Madrid', open: 9 * 60, close: 17 * 60 + 30, venue: 'BME', tzLabel: 'Madrid' },
+  SW: { zone: 'Europe/Zurich', open: 9 * 60, close: 17 * 60 + 30, venue: 'SIX', tzLabel: 'Zurich' },
+  VI: { zone: 'Europe/Vienna', open: 9 * 60, close: 17 * 60 + 30, venue: 'Wiener Börse', tzLabel: 'Vienna' },
+  ST: { zone: 'Europe/Stockholm', open: 9 * 60, close: 17 * 60 + 30, venue: 'Nasdaq Stockholm', tzLabel: 'Stockholm' },
+  CO: { zone: 'Europe/Copenhagen', open: 9 * 60, close: 17 * 60, venue: 'Nasdaq Copenhagen', tzLabel: 'Copenhagen' },
+  HE: { zone: 'Europe/Helsinki', open: 10 * 60, close: 18 * 60 + 30, venue: 'Nasdaq Helsinki', tzLabel: 'Helsinki' },
+  OL: { zone: 'Europe/Oslo', open: 9 * 60, close: 16 * 60 + 20, venue: 'Oslo Børs', tzLabel: 'Oslo' },
+  IR: { zone: 'Europe/Dublin', open: 8 * 60, close: 16 * 60 + 28, venue: 'Euronext Dublin', tzLabel: 'Dublin' },
+  TO: { zone: 'America/Toronto', open: 9 * 60 + 30, close: 16 * 60, venue: 'TSX', tzLabel: 'Toronto' },
+  V: { zone: 'America/Toronto', open: 9 * 60 + 30, close: 16 * 60, venue: 'TSXV', tzLabel: 'Toronto' },
+  HK: { zone: 'Asia/Hong_Kong', open: 9 * 60 + 30, close: 16 * 60, venue: 'HKEX', tzLabel: 'Hong Kong' },
+  T: { zone: 'Asia/Tokyo', open: 9 * 60, close: 15 * 60 + 30, venue: 'TSE', tzLabel: 'Tokyo' },
+  AX: { zone: 'Australia/Sydney', open: 10 * 60, close: 16 * 60, venue: 'ASX', tzLabel: 'Sydney' },
+}
+
+export function exchangeForSymbol(symbol) {
+  const normalized = String(symbol || '').trim().toUpperCase()
+  const lastDot = normalized.lastIndexOf('.')
+  if (lastDot === -1) return US
+
+  // A share class (BRK.B) is a US listing, not a venue suffix.
+  return EXCHANGES[normalized.slice(lastDot + 1)] || US
+}
+
+export const DEFAULT_EXCHANGE = US

--- a/frontend/src/utils/tradeMarketSession.js
+++ b/frontend/src/utils/tradeMarketSession.js
@@ -1,21 +1,4 @@
-const MARKET_TIMEZONE = 'America/New_York'
-const REGULAR_OPEN_MINUTES = 9 * 60 + 30
-const REGULAR_CLOSE_MINUTES = 16 * 60
-
-const marketPartsFormatter = new Intl.DateTimeFormat('en-US', {
-  timeZone: MARKET_TIMEZONE,
-  weekday: 'short',
-  hour: '2-digit',
-  minute: '2-digit',
-  hourCycle: 'h23',
-})
-
-const marketTimeFormatter = new Intl.DateTimeFormat('en-US', {
-  timeZone: MARKET_TIMEZONE,
-  hour: 'numeric',
-  minute: '2-digit',
-  hour12: true,
-})
+import { exchangeForSymbol } from './exchangeSessions'
 
 function parseTimestamp(value) {
   if (!value) return null
@@ -26,38 +9,77 @@ function parseTimestamp(value) {
   return Number.isNaN(date.getTime()) ? null : date
 }
 
-export function getTradeMarketSession(value) {
+const partsFormatterCache = new Map()
+const timeFormatterCache = new Map()
+
+function partsFormatter(zone) {
+  if (!partsFormatterCache.has(zone)) {
+    partsFormatterCache.set(zone, new Intl.DateTimeFormat('en-US', {
+      timeZone: zone,
+      weekday: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+      hourCycle: 'h23',
+    }))
+  }
+  return partsFormatterCache.get(zone)
+}
+
+function timeFormatter(zone) {
+  if (!timeFormatterCache.has(zone)) {
+    timeFormatterCache.set(zone, new Intl.DateTimeFormat('en-US', {
+      timeZone: zone,
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    }))
+  }
+  return timeFormatterCache.get(zone)
+}
+
+/**
+ * Classify a fill against the trading hours of the venue it was executed on.
+ * The venue comes from the symbol's suffix; without one it is a US listing.
+ * Judging a Frankfurt or London fill by New York hours mislabels the whole
+ * European morning as pre-market.
+ */
+export function getTradeMarketSession(value, symbol = null) {
   const date = parseTimestamp(value)
   if (!date) return null
 
+  const exchange = exchangeForSymbol(symbol)
+
   const parts = Object.fromEntries(
-    marketPartsFormatter.formatToParts(date).map((part) => [part.type, part.value])
+    partsFormatter(exchange.zone).formatToParts(date).map((part) => [part.type, part.value])
   )
 
   if (parts.weekday === 'Sat' || parts.weekday === 'Sun') return null
 
   const minutes = Number(parts.hour) * 60 + Number(parts.minute)
-  const timeLabel = `${marketTimeFormatter.format(date)} ET`
+  const timeLabel = `${timeFormatter(exchange.zone).format(date)} ${exchange.tzLabel}`
+  // Keep the original wording for a US listing; name the venue only when it is
+  // the thing that explains the hours.
+  const hours = exchange.venue === 'US' ? 'regular market hours' : `${exchange.venue} regular hours`
 
-  if (minutes < REGULAR_OPEN_MINUTES) {
+  if (minutes < exchange.open) {
     return {
       key: 'pre_market',
       label: 'Pre-market',
-      title: `Entered at ${timeLabel}, before regular market hours`,
+      title: `Entered at ${timeLabel}, before ${hours}`,
     }
   }
 
-  if (minutes < REGULAR_CLOSE_MINUTES) {
+  if (minutes < exchange.close) {
     return {
       key: 'regular',
       label: 'Market',
-      title: `Entered at ${timeLabel}, during regular market hours`,
+      title: `Entered at ${timeLabel}, during ${hours}`,
     }
   }
 
   return {
     key: 'post_market',
     label: 'Post-market',
-    title: `Entered at ${timeLabel}, after regular market hours`,
+    title: `Entered at ${timeLabel}, after ${hours}`,
   }
 }

--- a/frontend/src/utils/tradeMarketSession.test.js
+++ b/frontend/src/utils/tradeMarketSession.test.js
@@ -63,4 +63,40 @@ describe('getTradeMarketSession', () => {
         .toMatchObject({ key: 'regular' })
     })
   })
+
+  describe('exchange-qualified symbols from a TradingView import', () => {
+    it('reads the venue from the prefix', () => {
+      // 13:26Z is 14:26 in London, mid-session, but 09:26 in New York.
+      expect(getTradeMarketSession('2026-08-12T13:26:00.000Z', 'LSE:IGLN'))
+        .toMatchObject({ key: 'regular', label: 'Market' })
+      expect(getTradeMarketSession('2026-08-12T13:26:00.000Z', 'LSE:IGLN').title)
+        .toContain('LSE')
+    })
+
+    it('agrees with the suffix form of the same listing', () => {
+      const stamp = '2026-08-12T13:26:00.000Z'
+      expect(getTradeMarketSession(stamp, 'LSE:IGLN'))
+        .toEqual(getTradeMarketSession(stamp, 'IGLN.L'))
+    })
+
+    it('keeps US hours for a US prefix', () => {
+      expect(getTradeMarketSession('2025-01-02T14:30:00.000Z', 'NASDAQ:DEVS'))
+        .toMatchObject({ key: 'regular' })
+      expect(getTradeMarketSession('2025-01-02T13:00:00.000Z', 'NASDAQ:DEVS'))
+        .toMatchObject({ key: 'pre_market' })
+    })
+
+    it('covers the other prefixed venues', () => {
+      // 09:05Z is 11:05 in Frankfurt and Paris, 05:05 in New York.
+      expect(getTradeMarketSession('2026-08-14T09:05:00.000Z', 'XETR:BMW'))
+        .toMatchObject({ key: 'regular' })
+      expect(getTradeMarketSession('2026-08-14T09:05:00.000Z', 'EURONEXT:TTE'))
+        .toMatchObject({ key: 'regular' })
+    })
+
+    it('still reads a suffix when the prefix is unknown', () => {
+      expect(getTradeMarketSession('2026-08-12T13:26:00.000Z', 'AQUIS:IGLN.L'))
+        .toMatchObject({ key: 'regular' })
+    })
+  })
 })

--- a/frontend/src/utils/tradeMarketSession.test.js
+++ b/frontend/src/utils/tradeMarketSession.test.js
@@ -15,4 +15,52 @@ describe('getTradeMarketSession', () => {
     expect(getTradeMarketSession('not-a-date')).toBeNull()
     expect(getTradeMarketSession('2025-01-04T15:00:00.000Z')).toBeNull()
   })
+
+  describe('non-US listings are judged by their own venue', () => {
+    it('calls a mid-afternoon London fill regular hours', () => {
+      // 13:26Z is 14:26 in London — mid-session — but 09:26 in New York.
+      expect(getTradeMarketSession('2026-08-12T13:26:00.000Z', 'IGLN.L'))
+        .toMatchObject({ key: 'regular', label: 'Market' })
+      expect(getTradeMarketSession('2026-08-12T13:26:00.000Z'))
+        .toMatchObject({ key: 'pre_market' })
+    })
+
+    it('calls a German morning fill regular hours', () => {
+      // 09:05Z is 11:05 in Frankfurt, but 05:05 in New York.
+      expect(getTradeMarketSession('2026-08-14T09:05:00.000Z', 'BMW.DE'))
+        .toMatchObject({ key: 'regular', label: 'Market' })
+    })
+
+    it('calls a Paris morning fill regular hours', () => {
+      // Monday; 09:30Z is 11:30 in Paris.
+      expect(getTradeMarketSession('2026-05-04T09:30:00.000Z', 'TTE.PA'))
+        .toMatchObject({ key: 'regular', label: 'Market' })
+    })
+
+    it('still finds genuine pre- and post-market on a European venue', () => {
+      // 06:30Z = 07:30 London, before the 08:00 open.
+      expect(getTradeMarketSession('2026-08-12T06:30:00.000Z', 'IGLN.L'))
+        .toMatchObject({ key: 'pre_market' })
+      // 16:00Z = 17:00 London, after the 16:30 close.
+      expect(getTradeMarketSession('2026-08-12T16:00:00.000Z', 'IGLN.L'))
+        .toMatchObject({ key: 'post_market' })
+    })
+
+    it('names the venue in the tooltip so the hours are explicable', () => {
+      expect(getTradeMarketSession('2026-08-14T09:05:00.000Z', 'BMW.DE').title).toContain('XETRA')
+      expect(getTradeMarketSession('2026-08-12T13:26:00.000Z', 'IGLN.L').title).toContain('LSE')
+    })
+
+    it('treats a share class as the US listing it is, not a venue suffix', () => {
+      expect(getTradeMarketSession('2025-01-02T14:30:00.000Z', 'BRK.B'))
+        .toMatchObject({ key: 'regular' })
+      expect(getTradeMarketSession('2025-01-02T13:00:00.000Z', 'BRK.B'))
+        .toMatchObject({ key: 'pre_market' })
+    })
+
+    it('falls back to US hours for an unknown suffix', () => {
+      expect(getTradeMarketSession('2025-01-02T14:30:00.000Z', 'FOO.ZZ'))
+        .toMatchObject({ key: 'regular' })
+    })
+  })
 })


### PR DESCRIPTION
The session badge classified every trade against New York hours, so European fills read "Pre-market" for the whole trading morning. 
An LSE fill at 13:26Z showed "Pre-market" while one at 14:22Z showed "Market" — the second right only by coincidence, because it landed after the US open.

Sessions are now evaluated in the venue's own timezone and hours, taken from the symbol suffix, defaulting to US for a symbol that carries none. A share class such as BRK.B stays a US listing. An unrecognised suffix falls back to US hours rather than refusing to classify. The tooltip names the venue and local time; US trades keep their existing wording.

Frontend only — 4 files, one new util plus its tests. Full frontend suite passes (145).