### PR TITLE
fix(charts): call the lightweight-charts v5 API it depends on

### DIFF
--- a/frontend/src/components/investments/StockPriceChart.vue
+++ b/frontend/src/components/investments/StockPriceChart.vue
@@ -174,7 +174,7 @@ function createChart(candles) {
       },
     })
 
-    candleSeries = chart.addCandlestickSeries({
+    candleSeries = chart.addSeries(LightweightCharts.CandlestickSeries, {
       upColor: '#10b981',
       downColor: '#ef4444',
       borderUpColor: '#10b981',

--- a/frontend/src/components/replay/ReplayChart.vue
+++ b/frontend/src/components/replay/ReplayChart.vue
@@ -71,6 +71,7 @@ const { currencySymbol } = useCurrencyFormatter()
 const chartContainer = ref(null)
 let chart = null
 let candleSeries = null
+let candleMarkers = null
 let indicatorSeries = {} // key -> lightweight-charts series
 let indicatorData = null // key -> array aligned with props.candles
 let renderedCursor = -1
@@ -181,7 +182,9 @@ function createChart() {
       precision: Math.min(8, Math.max(2, Math.ceil(-Math.log10(tickSize))))
     }
   }
-  candleSeries = chart.addCandlestickSeries(seriesOptions)
+  candleSeries = chart.addSeries(LightweightCharts.CandlestickSeries, seriesOptions)
+  // Held rather than recreated: playback re-sets markers as fills come into view.
+  candleMarkers = LightweightCharts.createSeriesMarkers(candleSeries)
 
   // Only draw stop/target lines when they sit near the data — a level far
   // outside the bar range (mismatched fill/data spaces) would squash the
@@ -231,7 +234,7 @@ function createChart() {
   indicatorSeries = {}
   for (const key of ['vwap', 'ema9', 'ema20']) {
     if (props.indicators[key]) {
-      indicatorSeries[key] = chart.addLineSeries({
+      indicatorSeries[key] = chart.addSeries(LightweightCharts.LineSeries, {
         color: INDICATOR_STYLES[key].color,
         lineWidth: 1,
         title: INDICATOR_STYLES[key].title,
@@ -242,7 +245,7 @@ function createChart() {
     }
   }
   if (props.indicators.volume) {
-    indicatorSeries.volume = chart.addHistogramSeries({
+    indicatorSeries.volume = chart.addSeries(LightweightCharts.HistogramSeries, {
       priceScaleId: 'volume',
       priceFormat: { type: 'volume' },
       priceLineVisible: false,
@@ -278,6 +281,7 @@ function destroyChart() {
     }
     chart = null
     candleSeries = null
+    candleMarkers = null
     indicatorSeries = {}
     indicatorData = null
   }
@@ -343,7 +347,7 @@ function render(force = false) {
 
   if (force || props.executedFills.length !== renderedFillCount) {
     const visible = props.candles.slice(0, cursor + 1).map(shiftBar)
-    candleSeries.setMarkers(buildMarkers(visible))
+    candleMarkers?.setMarkers(buildMarkers(visible))
     renderedFillCount = props.executedFills.length
   }
 }

--- a/frontend/src/components/trade-management/TradeManagementChart.vue
+++ b/frontend/src/components/trade-management/TradeManagementChart.vue
@@ -135,6 +135,7 @@ const priceWarnings = ref([])  // Warnings about unreachable TP/SL
 const takeProfitAchievable = ref(null)  // null = no TP set, true = achievable, false = not achievable
 let chart = null
 let candleSeries = null
+let candleMarkers = null
 
 async function loadChart() {
   if (loading.value) return
@@ -336,8 +337,11 @@ function createChart() {
     },
   })
 
+  // Bound to the series that was just removed, so addTradeMarkers must build a new one.
+  candleMarkers = null
+
   // Create candlestick series - using softer, more muted colors
-  candleSeries = chart.addCandlestickSeries({
+  candleSeries = chart.addSeries(LightweightCharts.CandlestickSeries, {
     upColor: '#059669',      // emerald-600
     downColor: '#dc2626',    // red-600
     borderUpColor: '#059669',
@@ -517,7 +521,11 @@ function addTradeMarkers(candles) {
   if (markers.length > 0) {
     // Sort markers by time to ensure proper rendering
     markers.sort((a, b) => a.time - b.time)
-    candleSeries.setMarkers(markers)
+    if (!candleMarkers) {
+      candleMarkers = LightweightCharts.createSeriesMarkers(candleSeries, markers)
+    } else {
+      candleMarkers.setMarkers(markers)
+    }
     console.log('[CHART] Set', markers.length, 'trade markers')
   }
 


### PR DESCRIPTION
frontend/package.json pins lightweight-charts: ^5.2.0, but three components still call the v4 series helpers that v5 removed. addCandlestickSeries, addLineSeries and addHistogramSeries don't exist in any shipped v5 bundle — they survive only inside doc-comment examples in the typings — so each of these throws chart.addCandlestickSeries is not a function the moment it builds a chart:

components/replay/ReplayChart.vue
components/trade-management/TradeManagementChart.vue
components/investments/StockPriceChart.vue
This is a regression already on main rather than a new feature: all three have been dead since the dependency bump.

Changes

Pass a series definition to addSeries in place of the removed per-type helpers.
series.setMarkers went in the same release, so the two components that place execution markers hold a createSeriesMarkers plugin instance instead. Replay re-sets markers as fills come into view during playback, so the instance persists rather than being rebuilt per call; trade management rebuilds its chart when the trade changes, so the instance is dropped there and recreated with the new series.
The per-trade chart is unaffected — it uses klinecharts and never touched this library.

Verification

Full frontend suite passes (138) and vite build succeeds. Checked live in Replay: candlesticks, the VWAP line and the volume histogram all render, playback advances, and the console is clean. Trade management was checked across a trade switch, which is the path that exercises the marker-instance rebuild.

Frontend only, 3 files, +25/−7.