### PR TITLE
fix(currency): price non-US positions, and stop adding euros to dollars

### DIFF
--- a/backend/src/controllers/trade.controller.js
+++ b/backend/src/controllers/trade.controller.js
@@ -3015,11 +3015,13 @@ const tradeController = {
         // necessarily the currency the position is booked in: a broker may book
         // a EUR-quoted listing in USD. Comparing those directly invents P&L,
         // so convert first.
+        // A position whose currency could not be established (the same symbol
+        // held in two currencies) has no target to convert into; assuming the
+        // account's would invent the comparison this exists to prevent.
         const bookedCurrency = new Map(
-          Object.values(positionMap).map(position => [
-            position.symbol,
-            (position.currency || accountCurrency).toUpperCase()
-          ])
+          Object.values(positionMap)
+            .filter(position => position.currency)
+            .map(position => [position.symbol, String(position.currency).toUpperCase()])
         );
 
         const yahooQuotes = await Promise.all(
@@ -3028,6 +3030,7 @@ const tradeController = {
             if (!quote) return null;
 
             const target = bookedCurrency.get(symbol);
+            if (!target) return null;
             try {
               return await convertQuoteCurrency(quote, target);
             } catch (conversionError) {
@@ -3138,22 +3141,27 @@ const tradeController = {
 
       console.log('[PERF] getOpenPositionsWithQuotes total time:', Date.now() - requestStartedAt, 'ms');
 
-      // fxRate converts this position's native currency into the account's.
-      // null means no rate was available, which the UI must surface rather than
-      // quietly leaving the position out of a total.
+      // fx_rate converts this position's own currency into the account's. null
+      // means no usable rate, which the UI must surface rather than quietly
+      // dropping the position from a total or counting it at zero. A position
+      // with no established currency never gets a rate.
+      const usableRate = (value) => {
+        const rate = Number(value);
+        return Number.isFinite(rate) && rate > 0 ? rate : null;
+      };
       const normalisedPositions = enhancedPositions.map(position => {
-        const currency = (position.currency || accountCurrency).toUpperCase();
+        const currency = position.currency ? String(position.currency).toUpperCase() : null;
         return {
           ...position,
           currency,
-          accountCurrency,
-          fxRate: Object.hasOwn(fxRates, currency) ? fxRates[currency] : null
+          account_currency: accountCurrency,
+          fx_rate: currency ? usableRate(fxRates[currency]) : null
         };
       });
 
       res.json({
         positions: normalisedPositions,
-        accountCurrency,
+        account_currency: accountCurrency,
         quotesAvailable: Object.keys(quotes).length + Object.keys(alpacaQuotes).length,
         totalPositions: normalisedPositions.length,
         quotePending,

--- a/backend/src/controllers/trade.controller.js
+++ b/backend/src/controllers/trade.controller.js
@@ -9,7 +9,7 @@ const finnhub = require('../utils/finnhub');
 const cache = require('../utils/cache');
 const AnalyticsCache = require('../services/analyticsCache');
 const { computeTradePnl } = require('../services/pnlEngine');
-const { groupTradesIntoPositions } = require('../utils/openPositionGrouping');
+const { groupTradesIntoPositions, storedCurrency } = require('../utils/openPositionGrouping');
 const yahooFinance = require('../utils/yahooFinance');
 const { convertQuoteCurrency } = require('../utils/quoteCurrency');
 const symbolCategories = require('../utils/symbolCategories');
@@ -4102,9 +4102,11 @@ const tradeController = {
         // Trade details
         entryPrice: trade.price || trade.entry_price,
         exitPrice: trade.exit_price,
-        // The chart's summary row formats these, and a EUR fill labelled with
-        // the account's currency symbol is simply the wrong number.
-        currency: trade.original_currency || trade.currency || null,
+        // The chart's summary row formats entryPrice/exitPrice/pnl above, so it
+        // must be told the currency those STORED values are in. That is not
+        // original_currency: a converted import holds USD there while
+        // original_currency still names the source it came from.
+        currency: storedCurrency(trade) || trade.currency || null,
         quantity: trade.quantity,
         side: trade.side,
         pnl: trade.pnl,

--- a/backend/src/controllers/trade.controller.js
+++ b/backend/src/controllers/trade.controller.js
@@ -3004,6 +3004,10 @@ const tradeController = {
       // needs no key and covers the non-US listings Finnhub's free tier
       // refuses. Without this a European position shows no price at all.
       //
+      // A converted quote belongs to a position, not a symbol: two positions on
+      // one symbol can be booked in different currencies.
+      const convertedQuotesByPosition = {};
+
       // Self-hosted only, matching the gate the chart fallbacks already use: a
       // hosted instance must never reach this provider.
       const billingEnabled = await TierService.isBillingEnabled(req.headers.host);
@@ -3015,35 +3019,39 @@ const tradeController = {
         // necessarily the currency the position is booked in: a broker may book
         // a EUR-quoted listing in USD. Comparing those directly invents P&L,
         // so convert first.
-        // A position whose currency could not be established (the same symbol
-        // held in two currencies) has no target to convert into; assuming the
-        // account's would invent the comparison this exists to prevent.
-        const bookedCurrency = new Map(
-          Object.values(positionMap)
-            .filter(position => position.currency)
-            .map(position => [position.symbol, String(position.currency).toUpperCase()])
-        );
-
-        const yahooQuotes = await Promise.all(
+        // One raw quote per symbol, converted once PER POSITION. Positions are
+        // split by stored currency, so the same symbol can appear twice with
+        // different targets; keying the converted quote by symbol would give
+        // both positions whichever conversion ran last.
+        const unquoted = new Set(unquotedSymbols);
+        const rawQuotes = new Map();
+        await Promise.all(
           unquotedSymbols.map(async (symbol) => {
             const quote = await yahooFinance.getQuote(symbol).catch(() => null);
-            if (!quote) return null;
-
-            const target = bookedCurrency.get(symbol);
-            if (!target) return null;
-            try {
-              return await convertQuoteCurrency(quote, target);
-            } catch (conversionError) {
-              // Never show a number we cannot state the currency of.
-              console.warn(`[QUOTES] Dropping ${symbol} quote: cannot convert ${quote.currency} to ${target}: ${conversionError.message}`);
-              return null;
-            }
+            if (quote) rawQuotes.set(symbol, quote);
           })
         );
 
-        unquotedSymbols.forEach((symbol, index) => {
-          if (yahooQuotes[index]) quotes[symbol] = yahooQuotes[index];
-        });
+        await Promise.all(
+          Object.entries(positionMap).map(async ([posKey, position]) => {
+            if (!unquoted.has(position.symbol)) return;
+            const quote = rawQuotes.get(position.symbol);
+            if (!quote) return;
+
+            // A position with no established currency has no target to convert
+            // into; assuming the account's would invent the comparison this
+            // exists to prevent.
+            const target = position.currency ? String(position.currency).toUpperCase() : null;
+            if (!target) return;
+
+            try {
+              convertedQuotesByPosition[posKey] = await convertQuoteCurrency(quote, target);
+            } catch (conversionError) {
+              // Never show a number we cannot state the currency of.
+              console.warn(`[QUOTES] Dropping ${position.symbol} quote: cannot convert ${quote.currency} to ${target}: ${conversionError.message}`);
+            }
+          })
+        );
       }
 
       // Enhance positions with real-time data
@@ -3085,7 +3093,7 @@ const tradeController = {
           };
         }
 
-        const quote = quotes[position.symbol];
+        const quote = convertedQuotesByPosition[posKey] || quotes[position.symbol];
 
         if (quote) {
           const currentPrice = quote.c; // Current price
@@ -3162,7 +3170,11 @@ const tradeController = {
       res.json({
         positions: normalisedPositions,
         account_currency: accountCurrency,
-        quotesAvailable: Object.keys(quotes).length + Object.keys(alpacaQuotes).length,
+        // Fallback quotes are keyed per position rather than per symbol, so they
+        // have to be counted alongside the provider's own.
+        quotesAvailable: Object.keys(quotes).length
+          + Object.keys(alpacaQuotes).length
+          + Object.keys(convertedQuotesByPosition).length,
         totalPositions: normalisedPositions.length,
         quotePending,
         quoteFetchedAt: new Date().toISOString()

--- a/backend/src/controllers/trade.controller.js
+++ b/backend/src/controllers/trade.controller.js
@@ -10,6 +10,8 @@ const cache = require('../utils/cache');
 const AnalyticsCache = require('../services/analyticsCache');
 const { computeTradePnl } = require('../services/pnlEngine');
 const { groupTradesIntoPositions } = require('../utils/openPositionGrouping');
+const yahooFinance = require('../utils/yahooFinance');
+const { convertQuoteCurrency } = require('../utils/quoteCurrency');
 const symbolCategories = require('../utils/symbolCategories');
 const imageProcessor = require('../utils/imageProcessor');
 const ensureString = require('../utils/ensureString');
@@ -2968,6 +2970,79 @@ const tradeController = {
         console.log('Finnhub not configured, skipping stock quotes');
       }
 
+      // Aggregates across currencies are only meaningful once normalised, so
+      // resolve the account's display currency and a rate per position. Rows
+      // stay in their native currency; the UI converts only the totals.
+      let accountCurrency = 'USD';
+      try {
+        const settings = await User.getSettings(req.user.id);
+        accountCurrency = (settings?.display_currency || 'USD').toUpperCase();
+      } catch (settingsError) {
+        console.warn(`[CURRENCY] Could not read display currency, assuming USD: ${settingsError.message}`);
+      }
+
+      const positionCurrencies = [...new Set(
+        Object.values(positionMap)
+          .map(position => (position.currency || accountCurrency).toUpperCase())
+          .filter(currency => currency !== accountCurrency)
+      )];
+
+      const fxRates = { [accountCurrency]: 1 };
+      if (positionCurrencies.length > 0) {
+        await Promise.all(positionCurrencies.map(async (currency) => {
+          try {
+            fxRates[currency] = await currencyConverter.getForexRate(currency, accountCurrency);
+          } catch (rateError) {
+            // No rate means the UI must not fabricate a converted total.
+            console.warn(`[CURRENCY] No ${currency}/${accountCurrency} rate: ${rateError.message}`);
+            fxRates[currency] = null;
+          }
+        }));
+      }
+
+      // Anything the configured provider could not price falls to Yahoo, which
+      // needs no key and covers the non-US listings Finnhub's free tier
+      // refuses. Without this a European position shows no price at all.
+      //
+      // Self-hosted only, matching the gate the chart fallbacks already use: a
+      // hosted instance must never reach this provider.
+      const billingEnabled = await TierService.isBillingEnabled(req.headers.host);
+      const unquotedSymbols = billingEnabled
+        ? []
+        : symbols.filter(symbol => !quotes[symbol] && !pendingStockSymbols.has(symbol));
+      if (unquotedSymbols.length > 0 && yahooFinance.isEnabled()) {
+        // A quote arrives in the instrument's own currency, which is NOT
+        // necessarily the currency the position is booked in: a broker may book
+        // a EUR-quoted listing in USD. Comparing those directly invents P&L,
+        // so convert first.
+        const bookedCurrency = new Map(
+          Object.values(positionMap).map(position => [
+            position.symbol,
+            (position.currency || accountCurrency).toUpperCase()
+          ])
+        );
+
+        const yahooQuotes = await Promise.all(
+          unquotedSymbols.map(async (symbol) => {
+            const quote = await yahooFinance.getQuote(symbol).catch(() => null);
+            if (!quote) return null;
+
+            const target = bookedCurrency.get(symbol);
+            try {
+              return await convertQuoteCurrency(quote, target);
+            } catch (conversionError) {
+              // Never show a number we cannot state the currency of.
+              console.warn(`[QUOTES] Dropping ${symbol} quote: cannot convert ${quote.currency} to ${target}: ${conversionError.message}`);
+              return null;
+            }
+          })
+        );
+
+        unquotedSymbols.forEach((symbol, index) => {
+          if (yahooQuotes[index]) quotes[symbol] = yahooQuotes[index];
+        });
+      }
+
       // Enhance positions with real-time data
       const enhancedPositions = Object.entries(positionMap).map(([posKey, position]) => {
         // Options: use Alpaca quotes keyed by position key
@@ -3063,10 +3138,24 @@ const tradeController = {
 
       console.log('[PERF] getOpenPositionsWithQuotes total time:', Date.now() - requestStartedAt, 'ms');
 
+      // fxRate converts this position's native currency into the account's.
+      // null means no rate was available, which the UI must surface rather than
+      // quietly leaving the position out of a total.
+      const normalisedPositions = enhancedPositions.map(position => {
+        const currency = (position.currency || accountCurrency).toUpperCase();
+        return {
+          ...position,
+          currency,
+          accountCurrency,
+          fxRate: Object.hasOwn(fxRates, currency) ? fxRates[currency] : null
+        };
+      });
+
       res.json({
-        positions: enhancedPositions,
+        positions: normalisedPositions,
+        accountCurrency,
         quotesAvailable: Object.keys(quotes).length + Object.keys(alpacaQuotes).length,
-        totalPositions: enhancedPositions.length,
+        totalPositions: normalisedPositions.length,
         quotePending,
         quoteFetchedAt: new Date().toISOString()
       });
@@ -4005,6 +4094,9 @@ const tradeController = {
         // Trade details
         entryPrice: trade.price || trade.entry_price,
         exitPrice: trade.exit_price,
+        // The chart's summary row formats these, and a EUR fill labelled with
+        // the account's currency symbol is simply the wrong number.
+        currency: trade.original_currency || trade.currency || null,
         quantity: trade.quantity,
         side: trade.side,
         pnl: trade.pnl,

--- a/backend/src/models/Trade.js
+++ b/backend/src/models/Trade.js
@@ -1156,7 +1156,10 @@ class Trade {
         t.option_type,
         t.strike_price,
         t.trade_date,
-        t.entry_time
+        t.entry_time,
+        -- Positions can be held in a currency other than the account's; without
+        -- this the dashboard labels a EUR holding with the account's symbol.
+        t.original_currency
       FROM trades t
       ${whereClause}
       ORDER BY t.trade_date DESC, t.entry_time DESC

--- a/backend/src/models/Trade.js
+++ b/backend/src/models/Trade.js
@@ -1162,7 +1162,9 @@ class Trade {
         -- monetary columns are stored in: an import that converts leaves the
         -- stored values in USD, and exchange_rate is 1 exactly when it did not.
         t.original_currency,
-        t.exchange_rate
+        -- Written only when an import converted the monetary columns to USD;
+        -- that is the marker openPositionGrouping uses, not exchange_rate.
+        t.original_entry_price_currency
       FROM trades t
       ${whereClause}
       ORDER BY t.trade_date DESC, t.entry_time DESC

--- a/backend/src/models/Trade.js
+++ b/backend/src/models/Trade.js
@@ -1157,9 +1157,12 @@ class Trade {
         t.strike_price,
         t.trade_date,
         t.entry_time,
-        -- Positions can be held in a currency other than the account's; without
-        -- this the dashboard labels a EUR holding with the account's symbol.
-        t.original_currency
+        -- Positions can be held in a currency other than the account's. Note
+        -- original_currency names the SOURCE currency, not the currency the
+        -- monetary columns are stored in: an import that converts leaves the
+        -- stored values in USD, and exchange_rate is 1 exactly when it did not.
+        t.original_currency,
+        t.exchange_rate
       FROM trades t
       ${whereClause}
       ORDER BY t.trade_date DESC, t.entry_time DESC

--- a/backend/src/utils/alpacaMarketData.js
+++ b/backend/src/utils/alpacaMarketData.js
@@ -134,14 +134,19 @@ class AlpacaMarketDataClient {
 
       // Use _positionKey if provided (unique per contract), otherwise fall back to symbol
       const posKey = pos._positionKey || pos.symbol;
-      occToPositionKey[occ] = posKey;
+      // One OCC symbol can belong to SEVERAL positions: positions are split by
+      // the currency their stored values are in, so the same contract held in
+      // two currencies is two positions. Assigning a single key here would
+      // leave all but the last of them without a quote.
+      if (!occToPositionKey[occ]) occToPositionKey[occ] = [];
+      if (!occToPositionKey[occ].includes(posKey)) occToPositionKey[occ].push(posKey);
 
       // Check cache first (2 min TTL)
       const cached = cache.get(`alpaca_option:${occ}`);
       if (cached) {
         results[posKey] = cached;
         console.log(`[ALPACA] Cache hit for ${occ} -> $${cached.price}`);
-      } else {
+      } else if (!uncachedOcc.includes(occ)) {
         uncachedOcc.push(occ);
       }
     }
@@ -168,7 +173,7 @@ class AlpacaMarketDataClient {
 
         for (const occ of batch) {
           const snapshot = snapshots[occ];
-          const posKey = occToPositionKey[occ];
+          const posKeys = occToPositionKey[occ] || [];
 
           if (snapshot) {
             const bid = snapshot.latestQuote?.bp || snapshot.latestQuote?.bidPrice || 0;
@@ -187,7 +192,7 @@ class AlpacaMarketDataClient {
             }
 
             const result = { price, bid, ask };
-            results[posKey] = result;
+            posKeys.forEach(posKey => { results[posKey] = result; });
 
             // Cache for 2 minutes
             cache.set(`alpaca_option:${occ}`, result, 120000);

--- a/backend/src/utils/cache.js
+++ b/backend/src/utils/cache.js
@@ -47,7 +47,8 @@ const NAMESPACE_TTLS = {
   chart_intraday: 15 * MINUTE,
   chart_daily: HOUR,
   yahoo_chart_intraday: 15 * MINUTE,
-  yahoo_chart_daily: HOUR
+  yahoo_chart_daily: HOUR,
+  yahoo_quote: 2 * MINUTE
 };
 
 const SWEEP_INTERVAL_MS = MINUTE;

--- a/backend/src/utils/openPositionGrouping.js
+++ b/backend/src/utils/openPositionGrouping.js
@@ -153,7 +153,11 @@ function groupTradesIntoPositions(openTrades) {
         underlying_symbol: trade.underlying_symbol || null,
         expiration_date: trade.expiration_date || null,
         option_type: trade.option_type || null,
-        strike_price: trade.strike_price || null
+        strike_price: trade.strike_price || null,
+        // A position groups trades in one symbol, which are necessarily in one
+        // currency. Carrying it lets the UI label the value correctly instead
+        // of assuming the account's currency.
+        currency: trade.original_currency || null
       };
     }
 

--- a/backend/src/utils/openPositionGrouping.js
+++ b/backend/src/utils/openPositionGrouping.js
@@ -127,6 +127,18 @@ function calculateTotalSharesTraded(trade) {
   return trade.quantity || 0;
 }
 
+// The currency the stored monetary columns are actually in. An import with
+// currency conversion rewrites entry_price, pnl and fees to USD and keeps the
+// source currency in original_currency, so original_currency does NOT name the
+// currency of the stored numbers whenever a conversion ran. exchange_rate is
+// left at 1 exactly when nothing was converted.
+function storedCurrency(trade) {
+  const rate = Number(trade.exchange_rate);
+  if (Number.isFinite(rate) && rate !== 1) return 'USD';
+  const original = trade.original_currency;
+  return original ? String(original).toUpperCase() : null;
+}
+
 // Group open trades into positions. Returns a map of position key -> position
 // with side/avgPrice resolved, zero-net positions removed, and position_key
 // stamped on every surviving position.
@@ -154,11 +166,19 @@ function groupTradesIntoPositions(openTrades) {
         expiration_date: trade.expiration_date || null,
         option_type: trade.option_type || null,
         strike_price: trade.strike_price || null,
-        // A position groups trades in one symbol, which are necessarily in one
-        // currency. Carrying it lets the UI label the value correctly instead
-        // of assuming the account's currency.
-        currency: trade.original_currency || null
+        // The currency the position's own numbers are in, so the UI can label
+        // them instead of assuming the account's currency. Null means it could
+        // not be established, which callers must treat as unconvertible rather
+        // than assume.
+        currency: storedCurrency(trade)
       };
+    }
+
+    // The same symbol can be held in more than one currency across accounts.
+    // Such a group has no single currency, and saying it does would mislabel
+    // the value and invite a comparison between two different units.
+    if (positionMap[posKey].currency !== storedCurrency(trade)) {
+      positionMap[posKey].currency = null;
     }
 
     positionMap[posKey].trades.push(trade);
@@ -275,6 +295,7 @@ function groupTradesIntoPositions(openTrades) {
 }
 
 module.exports = {
+  storedCurrency,
   OPTION_FALLBACK_PREFIX,
   normalizeExpDate,
   enrichOptionMetadata,

--- a/backend/src/utils/openPositionGrouping.js
+++ b/backend/src/utils/openPositionGrouping.js
@@ -52,19 +52,43 @@ function enrichOptionMetadata(trade) {
   return trade;
 }
 
+// The currency the stored monetary columns are actually in. An import with
+// currency conversion rewrites entry_price, pnl and fees to USD while keeping
+// the SOURCE currency in original_currency, so original_currency does not name
+// the currency of the stored numbers whenever a conversion ran.
+function storedCurrency(trade) {
+  // Only a conversion writes the pre-conversion value, so its presence is the
+  // marker that the stored columns were rewritten. exchange_rate is NOT one: a
+  // manual, API or OAuth-broker trade can carry a rate beside an unconverted
+  // price, and a null rate coerces to 0, which would then read as converted.
+  const preConversion = trade.original_entry_price_currency;
+  if (preConversion !== null && preConversion !== undefined && preConversion !== '') {
+    return 'USD';
+  }
+
+  const original = trade.original_currency;
+  return original ? String(original).toUpperCase() : null;
+}
+
 function getPositionKey(trade) {
+  // Positions are separated by the currency their stored numbers are in.
+  // Without this, one symbol held in two currencies groups into a single
+  // position whose totalCost and avgPrice add different units together — a
+  // figure that cannot be labelled or converted correctly.
+  const currency = storedCurrency(trade) || 'UNKNOWN';
+
   if (trade.instrument_type === 'option' && trade.underlying_symbol
       && String(trade.underlying_symbol).trim()
       && trade.strike_price && trade.expiration_date && trade.option_type) {
     const underlying = String(trade.underlying_symbol).trim().toUpperCase();
     const strike = parseFloat(trade.strike_price);
     const optionType = String(trade.option_type).toLowerCase();
-    return `${underlying}_${strike}_${normalizeExpDate(trade.expiration_date)}_${optionType}`;
+    return `${underlying}_${strike}_${normalizeExpDate(trade.expiration_date)}_${optionType}|${currency}`;
   }
   if (trade.instrument_type === 'option') {
-    return `${OPTION_FALLBACK_PREFIX}${trade.symbol}`;
+    return `${OPTION_FALLBACK_PREFIX}${trade.symbol}|${currency}`;
   }
-  return trade.symbol;
+  return `${trade.symbol}|${currency}`;
 }
 
 // Calculate net position (signed shares/contracts still held) from executions
@@ -127,18 +151,6 @@ function calculateTotalSharesTraded(trade) {
   return trade.quantity || 0;
 }
 
-// The currency the stored monetary columns are actually in. An import with
-// currency conversion rewrites entry_price, pnl and fees to USD and keeps the
-// source currency in original_currency, so original_currency does NOT name the
-// currency of the stored numbers whenever a conversion ran. exchange_rate is
-// left at 1 exactly when nothing was converted.
-function storedCurrency(trade) {
-  const rate = Number(trade.exchange_rate);
-  if (Number.isFinite(rate) && rate !== 1) return 'USD';
-  const original = trade.original_currency;
-  return original ? String(original).toUpperCase() : null;
-}
-
 // Group open trades into positions. Returns a map of position key -> position
 // with side/avgPrice resolved, zero-net positions removed, and position_key
 // stamped on every surviving position.
@@ -172,13 +184,6 @@ function groupTradesIntoPositions(openTrades) {
         // than assume.
         currency: storedCurrency(trade)
       };
-    }
-
-    // The same symbol can be held in more than one currency across accounts.
-    // Such a group has no single currency, and saying it does would mislabel
-    // the value and invite a comparison between two different units.
-    if (positionMap[posKey].currency !== storedCurrency(trade)) {
-      positionMap[posKey].currency = null;
     }
 
     positionMap[posKey].trades.push(trade);

--- a/backend/src/utils/openPositionGrouping.js
+++ b/backend/src/utils/openPositionGrouping.js
@@ -225,8 +225,14 @@ function groupTradesIntoPositions(openTrades) {
     // positions share the bare underlying as their symbol, so with multiple
     // contracts open on the same underlying we cannot tell which one the
     // metadata-less trade belongs to.
+    // Never merge across currencies: an EUR fallback folded into a USD
+    // composite would put two units into one position's totalCost, which is
+    // exactly what keying by currency exists to prevent.
+    const sameCurrency = (pos) => pos.currency === fbPosition.currency;
+
     const symbolMatches = Object.entries(positionMap).filter(([key, pos]) => {
       return key !== fbKey && !fallbackKeys.has(key) && pos.instrumentType === 'option'
+        && sameCurrency(pos)
         && String(pos.symbol || '').trim().toUpperCase() === fbSymbol;
     });
     let compositeMatch = symbolMatches.length === 1 ? symbolMatches[0] : null;
@@ -236,6 +242,7 @@ function groupTradesIntoPositions(openTrades) {
     if (!compositeMatch) {
       const underlyingMatches = Object.entries(positionMap).filter(([key, pos]) => {
         return key !== fbKey && !fallbackKeys.has(key) && pos.instrumentType === 'option'
+          && sameCurrency(pos)
           && String(pos.underlying_symbol || '').trim().toUpperCase() === fbSymbol;
       });
       if (underlyingMatches.length === 1) {

--- a/backend/src/utils/quoteCurrency.js
+++ b/backend/src/utils/quoteCurrency.js
@@ -26,8 +26,9 @@ function normaliseMinorUnit(currency) {
 
 /**
  * Restate a quote in `targetCurrency`. Prices are scaled; percentage change is
- * currency-invariant and left alone. Throws when a rate cannot be obtained, so
- * the caller drops the quote rather than showing an unlabelled number.
+ * currency-invariant and left alone. Throws when the source currency is unknown
+ * or a rate cannot be obtained, so the caller drops the quote rather than
+ * showing a number whose unit it cannot state.
  */
 async function convertQuoteCurrency(quote, targetCurrency) {
   if (!quote) return quote;
@@ -35,8 +36,10 @@ async function convertQuoteCurrency(quote, targetCurrency) {
   const target = String(targetCurrency || '').trim().toUpperCase();
   const source = normaliseMinorUnit(quote.currency);
 
-  // Nothing to do without both sides, or when they already agree in the major unit.
-  if (!target || !source) return quote;
+  // A quote with no currency cannot be compared with anything: converting it
+  // would invent a unit, and passing it through would let a caller assume one.
+  if (!source) throw new Error('quote has no currency');
+  if (!target) return quote;
   if (source.code === target && source.divisor === 1) return quote;
 
   const rate = source.code === target
@@ -48,7 +51,13 @@ async function convertQuoteCurrency(quote, targetCurrency) {
   }
 
   const factor = Number(rate) / source.divisor;
-  const scale = (value) => (Number.isFinite(Number(value)) ? Number(value) * factor : value);
+  // A field the provider did not supply stays absent. Number(null) is 0, so
+  // coercing first would turn a missing high or low into a real-looking zero.
+  const scale = (value) => {
+    if (value === null || value === undefined || value === '') return value;
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric * factor : value;
+  };
 
   return {
     ...quote,

--- a/backend/src/utils/quoteCurrency.js
+++ b/backend/src/utils/quoteCurrency.js
@@ -1,0 +1,68 @@
+const currencyConverter = require('./currencyConverter');
+
+// Yahoo quotes UK listings in pence under the code "GBp"/"GBX", not pounds.
+// Treating that as GBP overstates a price a hundredfold.
+const MINOR_UNITS = {
+  GBP: { code: 'GBP', divisor: 100 },
+  ZAR: { code: 'ZAR', divisor: 100 },
+  ILS: { code: 'ILS', divisor: 100 }
+};
+
+function normaliseMinorUnit(currency) {
+  const raw = String(currency || '').trim();
+  if (!raw) return null;
+
+  // The minor-unit form is signalled by case ("GBp") or an X suffix ("GBX").
+  const upper = raw.toUpperCase();
+  const isMinor = (raw !== upper && raw.length === 3) || upper.endsWith('X');
+  const base = upper.endsWith('X') ? `${upper.slice(0, 2)}P` : upper;
+
+  if (isMinor && MINOR_UNITS[base]) {
+    return { code: MINOR_UNITS[base].code, divisor: MINOR_UNITS[base].divisor };
+  }
+
+  return { code: upper, divisor: 1 };
+}
+
+/**
+ * Restate a quote in `targetCurrency`. Prices are scaled; percentage change is
+ * currency-invariant and left alone. Throws when a rate cannot be obtained, so
+ * the caller drops the quote rather than showing an unlabelled number.
+ */
+async function convertQuoteCurrency(quote, targetCurrency) {
+  if (!quote) return quote;
+
+  const target = String(targetCurrency || '').trim().toUpperCase();
+  const source = normaliseMinorUnit(quote.currency);
+
+  // Nothing to do without both sides, or when they already agree in the major unit.
+  if (!target || !source) return quote;
+  if (source.code === target && source.divisor === 1) return quote;
+
+  const rate = source.code === target
+    ? 1
+    : await currencyConverter.getForexRate(source.code, target);
+
+  if (!Number.isFinite(Number(rate)) || Number(rate) <= 0) {
+    throw new Error(`invalid rate ${rate}`);
+  }
+
+  const factor = Number(rate) / source.divisor;
+  const scale = (value) => (Number.isFinite(Number(value)) ? Number(value) * factor : value);
+
+  return {
+    ...quote,
+    c: scale(quote.c),
+    pc: scale(quote.pc),
+    d: scale(quote.d),
+    h: scale(quote.h),
+    l: scale(quote.l),
+    o: scale(quote.o),
+    dp: quote.dp,
+    currency: target,
+    converted_from: quote.currency,
+    fx_rate: factor
+  };
+}
+
+module.exports = { convertQuoteCurrency, normaliseMinorUnit };

--- a/backend/src/utils/yahooFinance.js
+++ b/backend/src/utils/yahooFinance.js
@@ -334,6 +334,56 @@ class YahooFinanceClient {
     return resolution;
   }
 
+  // Latest price for a listing the configured provider cannot quote. Finnhub's
+  // free tier is US-only, so European holdings otherwise show no current price
+  // and no unrealized P&L at all. Shaped like the Finnhub quote the callers
+  // already consume: c = current, pc = previous close, d/dp = change.
+  async getQuote(symbol) {
+    if (!this.isEnabled()) return null;
+
+    const yahooSymbol = this.getYahooSymbol(symbol);
+    if (!yahooSymbol) return null;
+
+    const cached = await cache.get('yahoo_quote', yahooSymbol);
+    if (cached) return cached;
+
+    try {
+      const response = await axios.get(
+        `https://${YAHOO_CHART_HOSTS[0]}/v8/finance/chart/${encodeURIComponent(yahooSymbol)}`,
+        {
+          timeout: 8000,
+          headers: { Accept: 'application/json', 'User-Agent': 'TradeTally/2.9' },
+          params: { interval: '1d', range: '5d' }
+        }
+      );
+
+      const meta = response.data?.chart?.result?.[0]?.meta;
+      const current = asNumber(meta?.regularMarketPrice);
+      if (current === null) return null;
+
+      const previousClose = asNumber(meta?.chartPreviousClose) ?? asNumber(meta?.previousClose) ?? 0;
+      const change = previousClose ? current - previousClose : 0;
+
+      const quote = {
+        c: current,
+        pc: previousClose,
+        d: change,
+        dp: previousClose ? (change / previousClose) * 100 : 0,
+        h: asNumber(meta?.regularMarketDayHigh),
+        l: asNumber(meta?.regularMarketDayLow),
+        o: null,
+        currency: meta?.currency || null,
+        source: 'yahoo'
+      };
+
+      await cache.set('yahoo_quote', yahooSymbol, quote);
+      return quote;
+    } catch (error) {
+      console.warn(`[QUOTES] Yahoo Finance quote failed for ${yahooSymbol}: ${error.message}`);
+      return null;
+    }
+  }
+
   async getStockTradeChartData(symbol, entryDate, exitDate = null, requestedResolution = 'D') {
     if (!this.isEnabled()) {
       throw new Error('Yahoo Finance fallback is disabled');

--- a/backend/tests/utils/alpacaMarketData.currencySplit.test.js
+++ b/backend/tests/utils/alpacaMarketData.currencySplit.test.js
@@ -1,0 +1,41 @@
+jest.mock('../../src/utils/cache', () => ({ get: jest.fn(() => null), set: jest.fn() }));
+
+const cache = require('../../src/utils/cache');
+const alpacaMarketData = require('../../src/utils/alpacaMarketData');
+
+// Positions are split by the currency their stored values are in, so the same
+// option contract held in two currencies is two positions sharing one OCC
+// symbol. Both must receive the quote.
+function positionsSharingOneContract() {
+  const base = {
+    symbol: 'MRVL',
+    underlying_symbol: 'MRVL',
+    expiration_date: '2026-02-20',
+    option_type: 'put',
+    strike_price: 65,
+    instrumentType: 'option'
+  };
+  return [
+    { ...base, _positionKey: 'MRVL_65_2026-02-20_put|USD' },
+    { ...base, _positionKey: 'MRVL_65_2026-02-20_put|EUR' }
+  ];
+}
+
+describe('option snapshots for currency-split positions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Snapshots are skipped entirely unless credentials are present.
+    alpacaMarketData.apiKeyId = 'test-key';
+    alpacaMarketData.apiSecretKey = 'test-secret';
+  });
+
+  test('a cached quote reaches every position sharing the contract', async () => {
+    cache.get.mockReturnValue({ price: 2.5, bid: 2.4, ask: 2.6 });
+
+    const results = await alpacaMarketData.getOptionSnapshots(positionsSharingOneContract());
+
+    // Keying the OCC to a single position would leave one of them unpriced.
+    expect(results['MRVL_65_2026-02-20_put|USD']).toMatchObject({ price: 2.5 });
+    expect(results['MRVL_65_2026-02-20_put|EUR']).toMatchObject({ price: 2.5 });
+  });
+});

--- a/backend/tests/utils/openPositionGrouping.test.js
+++ b/backend/tests/utils/openPositionGrouping.test.js
@@ -29,7 +29,7 @@ describe('getPositionKey', () => {
     const b = getPositionKey(optionLeg({ underlying_symbol: 'MRVL', strike_price: 65, expiration_date: '2026-02-20', option_type: 'put' }));
 
     expect(a).toBe(b);
-    expect(a).toBe('MRVL_65_2026-02-20_put');
+    expect(a).toBe('MRVL_65_2026-02-20_put|UNKNOWN');
   });
 
   test('different strikes produce different keys', () => {
@@ -39,11 +39,16 @@ describe('getPositionKey', () => {
   });
 
   test('options without metadata get a namespaced fallback key, stocks keep plain symbol', () => {
+    // Every key is suffixed with the currency the stored values are in, so one
+    // symbol held in two currencies cannot collapse into a single position.
     const option = getPositionKey(optionLeg({ underlying_symbol: '', strike_price: null }));
-    expect(option).toBe(`${OPTION_FALLBACK_PREFIX}MRVL`);
+    expect(option).toBe(`${OPTION_FALLBACK_PREFIX}MRVL|UNKNOWN`);
 
     const stock = getPositionKey({ symbol: 'MRVL', instrument_type: 'stock' });
-    expect(stock).toBe('MRVL');
+    expect(stock).toBe('MRVL|UNKNOWN');
+
+    const eurStock = getPositionKey({ symbol: 'MRVL', instrument_type: 'stock', original_currency: 'EUR' });
+    expect(eurStock).toBe('MRVL|EUR');
   });
 });
 
@@ -116,7 +121,7 @@ describe('groupTradesIntoPositions', () => {
     ]);
 
     expect(Object.keys(positions)).toHaveLength(1);
-    expect(positions['MRVL_65_2026-02-20_put'].totalQuantity).toBe(3);
+    expect(positions['MRVL_65_2026-02-20_put|UNKNOWN'].totalQuantity).toBe(3);
   });
 
   test('different contracts on the same underlying stay separate with distinct keys', () => {
@@ -137,9 +142,9 @@ describe('groupTradesIntoPositions', () => {
       optionLeg({ id: 'opt-1', symbol: 'MRVL', underlying_symbol: '', strike_price: null, expiration_date: null, option_type: null, quantity: 1 })
     ]);
 
-    expect(positions['MRVL'].instrumentType).toBe('stock');
-    expect(positions['MRVL'].totalQuantity).toBe(100);
-    expect(positions[`${OPTION_FALLBACK_PREFIX}MRVL`].instrumentType).toBe('option');
+    expect(positions['MRVL|UNKNOWN'].instrumentType).toBe('stock');
+    expect(positions['MRVL|UNKNOWN'].totalQuantity).toBe(100);
+    expect(positions[`${OPTION_FALLBACK_PREFIX}MRVL|UNKNOWN`].instrumentType).toBe('option');
   });
 
   test('heal-merge folds an unparseable fallback into the single matching contract', () => {
@@ -149,7 +154,7 @@ describe('groupTradesIntoPositions', () => {
     ]);
 
     expect(Object.keys(positions)).toHaveLength(1);
-    expect(positions['MRVL_65_2026-02-20_put'].totalQuantity).toBe(3);
+    expect(positions['MRVL_65_2026-02-20_put|UNKNOWN'].totalQuantity).toBe(3);
   });
 
   test('heal-merge refuses ambiguous merges across multiple contracts', () => {
@@ -160,7 +165,7 @@ describe('groupTradesIntoPositions', () => {
     ]);
 
     expect(Object.keys(positions)).toHaveLength(3);
-    expect(positions[`${OPTION_FALLBACK_PREFIX}MRVL`]).toBeDefined();
+    expect(positions[`${OPTION_FALLBACK_PREFIX}MRVL|UNKNOWN`]).toBeDefined();
   });
 
   test('two metadata-less legs sharing a symbol merge under one fallback key', () => {
@@ -170,7 +175,7 @@ describe('groupTradesIntoPositions', () => {
     ]);
 
     expect(Object.keys(positions)).toHaveLength(1);
-    expect(positions[`${OPTION_FALLBACK_PREFIX}XYZ`].totalQuantity).toBe(3);
+    expect(positions[`${OPTION_FALLBACK_PREFIX}XYZ|UNKNOWN`].totalQuantity).toBe(3);
   });
 
   test('removes zero-net positions and computes avgPrice with the contract multiplier', () => {
@@ -183,7 +188,7 @@ describe('groupTradesIntoPositions', () => {
 
     // The AAPL position nets to zero via its closed round-trip execution.
     expect(Object.keys(positions)).toHaveLength(1);
-    const mrvl = positions['MRVL_65_2026-02-20_put'];
+    const mrvl = positions['MRVL_65_2026-02-20_put|UNKNOWN'];
     expect(mrvl.side).toBe('short');
     expect(mrvl.totalQuantity).toBe(2);
     // totalCost = |net| * entry * contract_size = 2 * 1.5 * 100 = 300
@@ -267,7 +272,47 @@ describe('stored currency vs original_currency', () => {
     expect(Object.values(positions)[0].currency).toBe('EUR');
   });
 
-  test('states no currency when one symbol is held in two of them', () => {
+  test('does not treat a non-1 exchange_rate as proof of conversion', () => {
+    // A manual, API or OAuth-broker trade can carry a rate beside a price that
+    // was never rewritten. Only the pre-conversion value proves a conversion.
+    const positions = groupTradesIntoPositions([
+      {
+        id: 't7',
+        symbol: 'EXCO.DE',
+        side: 'long',
+        quantity: 10,
+        entry_price: 100,
+        instrument_type: 'stock',
+        original_currency: 'EUR',
+        exchange_rate: 1.5,
+        executions: [{ action: 'buy', quantity: 10, price: 100 }]
+      }
+    ]);
+
+    expect(Object.values(positions)[0].currency).toBe('EUR');
+  });
+
+  test('does not read a null exchange_rate as USD', () => {
+    // Number(null) is 0, which is not 1 — coercing first would call this
+    // converted and label a EUR position in dollars.
+    const positions = groupTradesIntoPositions([
+      {
+        id: 't8',
+        symbol: 'EXCO.DE',
+        side: 'long',
+        quantity: 10,
+        entry_price: 100,
+        instrument_type: 'stock',
+        original_currency: 'EUR',
+        exchange_rate: null,
+        executions: [{ action: 'buy', quantity: 10, price: 100 }]
+      }
+    ]);
+
+    expect(Object.values(positions)[0].currency).toBe('EUR');
+  });
+
+  test('separates one symbol held in two currencies into two positions', () => {
     const positions = groupTradesIntoPositions([
       {
         id: 't5',
@@ -289,12 +334,17 @@ describe('stored currency vs original_currency', () => {
         entry_price: 150,
         instrument_type: 'stock',
         original_currency: 'EUR',
-        exchange_rate: 1.5,
+        original_entry_price_currency: 100,
         account_identifier: 'B',
         executions: [{ action: 'buy', quantity: 10, price: 150 }]
       }
     ]);
 
-    expect(Object.values(positions)[0].currency).toBeNull();
+    // Two positions, each with its own currency — never one group whose
+    // totalCost adds euros to dollars.
+    const grouped = Object.values(positions);
+    expect(grouped).toHaveLength(2);
+    expect(grouped.map(p => p.currency).sort()).toEqual(['EUR', 'USD']);
+    grouped.forEach(position => expect(position.totalCost).toBeGreaterThan(0));
   });
 });

--- a/backend/tests/utils/openPositionGrouping.test.js
+++ b/backend/tests/utils/openPositionGrouping.test.js
@@ -226,3 +226,75 @@ describe('position currency', () => {
     expect(Object.values(positions)[0].currency).toBeNull();
   });
 });
+
+describe('stored currency vs original_currency', () => {
+  // A converted import stores USD and keeps the source currency in
+  // original_currency, so the two disagree exactly when a conversion ran.
+  test('reports USD for a converted import, not the source currency', () => {
+    const positions = groupTradesIntoPositions([
+      {
+        id: 't3',
+        symbol: 'EXCO.DE',
+        side: 'long',
+        quantity: 10,
+        entry_price: 150,
+        instrument_type: 'stock',
+        original_currency: 'EUR',
+        exchange_rate: 1.5,
+        original_entry_price_currency: 100,
+        executions: [{ action: 'buy', quantity: 10, price: 150 }]
+      }
+    ]);
+
+    expect(Object.values(positions)[0].currency).toBe('USD');
+  });
+
+  test('reports the trade currency when nothing was converted', () => {
+    const positions = groupTradesIntoPositions([
+      {
+        id: 't4',
+        symbol: 'EXCO.DE',
+        side: 'long',
+        quantity: 10,
+        entry_price: 100,
+        instrument_type: 'stock',
+        original_currency: 'EUR',
+        exchange_rate: 1,
+        executions: [{ action: 'buy', quantity: 10, price: 100 }]
+      }
+    ]);
+
+    expect(Object.values(positions)[0].currency).toBe('EUR');
+  });
+
+  test('states no currency when one symbol is held in two of them', () => {
+    const positions = groupTradesIntoPositions([
+      {
+        id: 't5',
+        symbol: 'EXCO.DE',
+        side: 'long',
+        quantity: 10,
+        entry_price: 100,
+        instrument_type: 'stock',
+        original_currency: 'EUR',
+        exchange_rate: 1,
+        account_identifier: 'A',
+        executions: [{ action: 'buy', quantity: 10, price: 100 }]
+      },
+      {
+        id: 't6',
+        symbol: 'EXCO.DE',
+        side: 'long',
+        quantity: 10,
+        entry_price: 150,
+        instrument_type: 'stock',
+        original_currency: 'EUR',
+        exchange_rate: 1.5,
+        account_identifier: 'B',
+        executions: [{ action: 'buy', quantity: 10, price: 150 }]
+      }
+    ]);
+
+    expect(Object.values(positions)[0].currency).toBeNull();
+  });
+});

--- a/backend/tests/utils/openPositionGrouping.test.js
+++ b/backend/tests/utils/openPositionGrouping.test.js
@@ -191,3 +191,38 @@ describe('groupTradesIntoPositions', () => {
     expect(mrvl.avgPrice).toBeCloseTo(1.5, 6);
   });
 });
+
+describe('position currency', () => {
+  test('carries the trade currency onto the grouped position', () => {
+    const positions = groupTradesIntoPositions([
+      {
+        id: 't1',
+        symbol: 'EXCO.DE',
+        side: 'long',
+        quantity: 10,
+        entry_price: 100,
+        instrument_type: 'stock',
+        original_currency: 'EUR',
+        executions: [{ action: 'buy', quantity: 10, price: 100 }]
+      }
+    ]);
+
+    expect(Object.values(positions)[0].currency).toBe('EUR');
+  });
+
+  test('leaves the currency null when the trade does not record one', () => {
+    const positions = groupTradesIntoPositions([
+      {
+        id: 't2',
+        symbol: 'EXCO',
+        side: 'long',
+        quantity: 1,
+        entry_price: 50,
+        instrument_type: 'stock',
+        executions: [{ action: 'buy', quantity: 1, price: 50 }]
+      }
+    ]);
+
+    expect(Object.values(positions)[0].currency).toBeNull();
+  });
+});

--- a/backend/tests/utils/openPositionGrouping.test.js
+++ b/backend/tests/utils/openPositionGrouping.test.js
@@ -348,3 +348,39 @@ describe('stored currency vs original_currency', () => {
     grouped.forEach(position => expect(position.totalCost).toBeGreaterThan(0));
   });
 });
+
+describe('heal-merge respects currency', () => {
+  const composite = (over = {}) => ({
+    id: 'c1', symbol: 'MRVL', side: 'long', quantity: 1, entry_price: 100,
+    instrument_type: 'option', underlying_symbol: 'MRVL', strike_price: 65,
+    expiration_date: '2026-02-20', option_type: 'put',
+    executions: [{ action: 'buy', quantity: 1, price: 100 }], ...over
+  });
+  const fallback = (over = {}) => ({
+    id: 'f1', symbol: 'MRVL', side: 'long', quantity: 2, entry_price: 100,
+    instrument_type: 'option',
+    executions: [{ action: 'buy', quantity: 2, price: 100 }], ...over
+  });
+
+  test('does not fold a EUR fallback into a USD composite position', () => {
+    const positions = groupTradesIntoPositions([
+      composite({ original_currency: 'USD' }),
+      fallback({ original_currency: 'EUR' })
+    ]);
+
+    // Merging would add EUR contracts into a USD position's totalCost.
+    const grouped = Object.values(positions);
+    expect(grouped).toHaveLength(2);
+    expect(grouped.map(p => p.currency).sort()).toEqual(['EUR', 'USD']);
+  });
+
+  test('still folds a fallback into a composite of the same currency', () => {
+    const positions = groupTradesIntoPositions([
+      composite({ original_currency: 'USD' }),
+      fallback({ original_currency: 'USD' })
+    ]);
+
+    expect(Object.keys(positions)).toHaveLength(1);
+    expect(Object.values(positions)[0].totalQuantity).toBe(3);
+  });
+});

--- a/backend/tests/utils/quoteCurrency.test.js
+++ b/backend/tests/utils/quoteCurrency.test.js
@@ -109,3 +109,24 @@ describe('fields the provider did not supply', () => {
     expect(converted.h).toBeUndefined();
   });
 });
+
+describe('one raw quote converted for two currency-split positions', () => {
+  test('each position gets its own target, not whichever ran last', async () => {
+    // Positions are split by stored currency, so the same symbol can appear
+    // twice. Converting once per SYMBOL would give both the same result.
+    const raw = { c: 100, pc: 100, d: 0, dp: 0, h: 100, l: 100, o: null, currency: 'EUR' };
+
+    currencyConverter.getForexRate.mockResolvedValue(1.5);
+    const asUsd = await convertQuoteCurrency({ ...raw }, 'USD');
+
+    currencyConverter.getForexRate.mockClear();
+    const asEur = await convertQuoteCurrency({ ...raw }, 'EUR');
+
+    expect(asUsd.c).toBeCloseTo(150, 2);
+    expect(asUsd.currency).toBe('USD');
+    // Already in EUR: passed through untouched, with no rate lookup.
+    expect(asEur.c).toBe(100);
+    expect(asEur.currency).toBe('EUR');
+    expect(currencyConverter.getForexRate).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/utils/quoteCurrency.test.js
+++ b/backend/tests/utils/quoteCurrency.test.js
@@ -73,3 +73,39 @@ describe('convertQuoteCurrency', () => {
     expect(normaliseMinorUnit('EUR')).toEqual({ code: 'EUR', divisor: 1 });
   });
 });
+
+describe('quotes the converter must refuse', () => {
+  test('throws when the quote carries no currency', async () => {
+    await expect(convertQuoteCurrency(quote({ currency: null }), 'USD'))
+      .rejects.toThrow(/no currency/);
+    expect(currencyConverter.getForexRate).not.toHaveBeenCalled();
+  });
+
+  test('throws on an empty currency rather than assuming the target', async () => {
+    await expect(convertQuoteCurrency(quote({ currency: '' }), 'USD'))
+      .rejects.toThrow(/no currency/);
+  });
+});
+
+describe('fields the provider did not supply', () => {
+  test('leaves null OHLC null instead of converting it to zero', async () => {
+    currencyConverter.getForexRate.mockResolvedValue(1.5);
+
+    const converted = await convertQuoteCurrency(
+      quote({ h: null, l: null, o: null }),
+      'USD'
+    );
+
+    expect(converted.h).toBeNull();
+    expect(converted.l).toBeNull();
+    expect(converted.o).toBeNull();
+    // The fields that were present are still converted.
+    expect(converted.c).toBeCloseTo(150, 2);
+  });
+
+  test('leaves an undefined field undefined', async () => {
+    currencyConverter.getForexRate.mockResolvedValue(1.5);
+    const converted = await convertQuoteCurrency(quote({ h: undefined }), 'USD');
+    expect(converted.h).toBeUndefined();
+  });
+});

--- a/backend/tests/utils/quoteCurrency.test.js
+++ b/backend/tests/utils/quoteCurrency.test.js
@@ -1,0 +1,75 @@
+jest.mock('../../src/utils/currencyConverter', () => ({
+  getForexRate: jest.fn()
+}));
+
+const currencyConverter = require('../../src/utils/currencyConverter');
+const { convertQuoteCurrency, normaliseMinorUnit } = require('../../src/utils/quoteCurrency');
+
+function quote(overrides = {}) {
+  return { c: 100, pc: 80, d: 20, dp: 25, h: 110, l: 90, o: null, currency: 'EUR', ...overrides };
+}
+
+describe('convertQuoteCurrency', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('restates a EUR quote in the USD the position is booked in', async () => {
+    currencyConverter.getForexRate.mockResolvedValue(1.5);
+
+    const converted = await convertQuoteCurrency(quote(), 'USD');
+
+    expect(converted.c).toBeCloseTo(150, 2);
+    expect(converted.pc).toBeCloseTo(120, 2);
+    expect(converted.currency).toBe('USD');
+    expect(converted.converted_from).toBe('EUR');
+  });
+
+  test('leaves the percentage change alone, since it is currency-invariant', async () => {
+    currencyConverter.getForexRate.mockResolvedValue(1.5);
+    const converted = await convertQuoteCurrency(quote(), 'USD');
+    expect(converted.dp).toBe(25);
+  });
+
+  test('does not call the converter when the currencies already agree', async () => {
+    const converted = await convertQuoteCurrency(quote({ currency: 'USD' }), 'USD');
+    expect(currencyConverter.getForexRate).not.toHaveBeenCalled();
+    expect(converted.c).toBe(100);
+  });
+
+  test('treats GBp as pence, not pounds', async () => {
+    currencyConverter.getForexRate.mockResolvedValue(2);
+
+    // 1000 pence = GBP 10 = USD 20, not USD 2000.
+    const converted = await convertQuoteCurrency(quote({ c: 1000, pc: 900, d: 100, currency: 'GBp' }), 'USD');
+
+    expect(converted.c).toBeCloseTo(20, 3);
+    expect(currencyConverter.getForexRate).toHaveBeenCalledWith('GBP', 'USD');
+  });
+
+  test('handles the GBX spelling of pence too', async () => {
+    currencyConverter.getForexRate.mockResolvedValue(2);
+    const converted = await convertQuoteCurrency(quote({ c: 1000, currency: 'GBX' }), 'USD');
+    expect(converted.c).toBeCloseTo(20, 3);
+  });
+
+  test('converts pence to pounds without a rate lookup', async () => {
+    const converted = await convertQuoteCurrency(quote({ c: 1000, currency: 'GBp' }), 'GBP');
+    expect(converted.c).toBeCloseTo(10, 3);
+    expect(currencyConverter.getForexRate).not.toHaveBeenCalled();
+  });
+
+  test('throws rather than returning an unconvertible number', async () => {
+    currencyConverter.getForexRate.mockRejectedValue(new Error('no rate'));
+    await expect(convertQuoteCurrency(quote(), 'USD')).rejects.toThrow('no rate');
+  });
+
+  test('throws when the converter returns nonsense', async () => {
+    currencyConverter.getForexRate.mockResolvedValue(0);
+    await expect(convertQuoteCurrency(quote(), 'USD')).rejects.toThrow(/invalid rate/);
+  });
+
+  test('normaliseMinorUnit distinguishes the major and minor forms', () => {
+    expect(normaliseMinorUnit('GBp')).toEqual({ code: 'GBP', divisor: 100 });
+    expect(normaliseMinorUnit('GBP')).toEqual({ code: 'GBP', divisor: 1 });
+    expect(normaliseMinorUnit('EUR')).toEqual({ code: 'EUR', divisor: 1 });
+  });
+});

--- a/backend/tests/utils/yahooFinance.stocks.test.js
+++ b/backend/tests/utils/yahooFinance.stocks.test.js
@@ -189,3 +189,63 @@ describe('advertised resolutions match what can be served', () => {
   });
 });
 
+describe('Yahoo Finance quotes', () => {
+  let originalEnabled;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    originalEnabled = process.env.YAHOO_FINANCE_ENABLED;
+    process.env.YAHOO_FINANCE_ENABLED = 'true';
+  });
+
+  afterEach(() => {
+    if (originalEnabled === undefined) delete process.env.YAHOO_FINANCE_ENABLED;
+    else process.env.YAHOO_FINANCE_ENABLED = originalEnabled;
+  });
+
+  function quoteResponse(meta) {
+    return { data: { chart: { error: null, result: [{ meta, timestamp: [], indicators: { quote: [{}] } }] } } };
+  }
+
+  test('shapes the quote like the Finnhub one the callers already consume', async () => {
+    axios.get.mockResolvedValue(quoteResponse({
+      regularMarketPrice: 100,
+      chartPreviousClose: 80,
+      currency: 'EUR',
+      regularMarketDayHigh: 110,
+      regularMarketDayLow: 90
+    }));
+
+    const quote = await yahooFinance.getQuote('EXCO.DE');
+
+    expect(quote.c).toBe(100);
+    expect(quote.pc).toBe(80);
+    expect(quote.d).toBeCloseTo(20, 2);
+    expect(quote.dp).toBeCloseTo(25, 2);
+    expect(quote.currency).toBe('EUR');
+    expect(quote.source).toBe('yahoo');
+  });
+
+  test('returns null rather than a bogus quote when there is no price', async () => {
+    axios.get.mockResolvedValue(quoteResponse({ currency: 'EUR' }));
+    expect(await yahooFinance.getQuote('EXCO.DE')).toBeNull();
+  });
+
+  test('never throws when the request fails', async () => {
+    axios.get.mockRejectedValue(new Error('network down'));
+    expect(await yahooFinance.getQuote('EXCO.DE')).toBeNull();
+  });
+
+  test('translates the symbol before quoting', async () => {
+    axios.get.mockResolvedValue(quoteResponse({ regularMarketPrice: 100, chartPreviousClose: 99 }));
+    await yahooFinance.getQuote('SPX');
+    expect(axios.get.mock.calls[0][0]).toContain(encodeURIComponent('^SPX'));
+  });
+
+  test('does not divide by a zero previous close', async () => {
+    axios.get.mockResolvedValue(quoteResponse({ regularMarketPrice: 12, chartPreviousClose: 0 }));
+    const quote = await yahooFinance.getQuote('NEWLISTING');
+    expect(quote.dp).toBe(0);
+    expect(Number.isFinite(quote.dp)).toBe(true);
+  });
+});

--- a/frontend/src/components/trades/TradeChartVisualization.test.js
+++ b/frontend/src/components/trades/TradeChartVisualization.test.js
@@ -10,9 +10,18 @@ vi.mock('@/stores/auth', () => ({
     user: { tier: 'pro', role: 'user', billingEnabled: false, timezone: 'America/New_York' },
   }),
 }))
-vi.mock('@/composables/useCurrencyFormatter', () => ({
-  useCurrencyFormatter: () => ({ formatCurrency: (value) => `$${Number(value).toFixed(2)}` }),
-}))
+vi.mock('@/composables/useCurrencyFormatter', async () => {
+  const { ref } = await import('vue')
+  // Mirror the real composable, which also exposes currencyCode: the chart
+  // summary formats in the trade's own currency and falls back to this.
+  return {
+    useCurrencyFormatter: () => ({
+      currencyCode: ref('USD'),
+      formatCurrency: (value, options = {}) =>
+        `${options.currency === 'EUR' ? '\u20ac' : '$'}${Number(value).toFixed(2)}`,
+    }),
+  }
+})
 vi.mock('@/composables/useNotification', () => ({
   useNotification: () => ({ showError: vi.fn(), showWarning: vi.fn() }),
 }))
@@ -271,5 +280,64 @@ describe('TradeChartVisualization resolutions', () => {
     await vi.waitFor(() => expect(wrapper.text()).toContain('Yahoo Finance'))
 
     expect(wrapper.text()).toContain('continuous front-month data (ES=F)')
+  })
+})
+
+
+describe('TradeChartVisualization currency', () => {
+  beforeEach(() => {
+    apiGet.mockReset()
+    sessionStorage.clear()
+    localStorage.clear()
+  })
+
+  it('formats the summary in the trade currency, not the account currency', async () => {
+    apiGet.mockResolvedValue({
+      data: {
+        ...baseChartData,
+        interval: 'daily',
+        source: 'yahoo',
+        trade: { ...baseChartData.trade, entryPrice: 100, exitPrice: null, pnl: null, currency: 'EUR' },
+      },
+    })
+
+    const wrapper = mount(TradeChartVisualization, {
+      props: { tradeId: 'trade-eur' },
+      global: {
+        stubs: {
+          KLineTradeChart: true,
+          ProUpgradePrompt: true,
+        },
+      },
+    })
+
+    await wrapper.get('button.btn-primary').trigger('click')
+    await vi.waitFor(() => expect(apiGet).toHaveBeenCalled())
+    await vi.waitFor(() => expect(wrapper.text()).toContain('\u20ac100.00'))
+
+    expect(wrapper.text()).not.toContain('$100.00')
+  })
+
+  it('falls back to the account currency when the trade carries none', async () => {
+    apiGet.mockResolvedValue({
+      data: {
+        ...baseChartData,
+        interval: 'daily',
+        trade: { ...baseChartData.trade, entryPrice: 100, currency: null },
+      },
+    })
+
+    const wrapper = mount(TradeChartVisualization, {
+      props: { tradeId: 'trade-no-currency' },
+      global: {
+        stubs: {
+          KLineTradeChart: true,
+          ProUpgradePrompt: true,
+        },
+      },
+    })
+
+    await wrapper.get('button.btn-primary').trigger('click')
+    await vi.waitFor(() => expect(wrapper.text()).toContain('$100.00'))
   })
 })

--- a/frontend/src/components/trades/TradeChartVisualization.test.js
+++ b/frontend/src/components/trades/TradeChartVisualization.test.js
@@ -318,6 +318,31 @@ describe('TradeChartVisualization currency', () => {
     expect(wrapper.text()).not.toContain('$100.00')
   })
 
+  it('labels a converted import in the currency its stored values are in', async () => {
+    // A converted import stores USD while original_currency still names the
+    // source, so the API must send the STORED currency. Sending the source
+    // would render a stored $100 as EUR 100.
+    apiGet.mockResolvedValue({
+      data: {
+        ...baseChartData,
+        interval: 'daily',
+        source: 'yahoo',
+        trade: { ...baseChartData.trade, entryPrice: 100, exitPrice: null, pnl: null, currency: 'USD' },
+      },
+    })
+
+    const wrapper = mount(TradeChartVisualization, {
+      props: { tradeId: 'trade-converted' },
+      global: { stubs: { KLineTradeChart: true, ProUpgradePrompt: true } },
+    })
+
+    await wrapper.get('button.btn-primary').trigger('click')
+    await vi.waitFor(() => expect(apiGet).toHaveBeenCalled())
+    await vi.waitFor(() => expect(wrapper.text()).toContain('$100.00'))
+
+    expect(wrapper.text()).not.toContain('\u20ac100.00')
+  })
+
   it('falls back to the account currency when the trade carries none', async () => {
     apiGet.mockResolvedValue({
       data: {

--- a/frontend/src/components/trades/TradeChartVisualization.vue
+++ b/frontend/src/components/trades/TradeChartVisualization.vue
@@ -109,7 +109,7 @@
         <dl v-if="chartData.trade" class="mt-4 grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">
           <div class="rounded-lg bg-gray-50 px-3 py-2 dark:bg-gray-800/70">
             <dt class="text-gray-500 dark:text-gray-400">Entry</dt>
-            <dd class="mt-0.5 font-semibold text-gray-900 dark:text-white">{{ formatCurrency(chartData.trade.entryPrice) }}</dd>
+            <dd class="mt-0.5 font-semibold text-gray-900 dark:text-white">{{ formatTradeCurrency(chartData.trade.entryPrice) }}</dd>
           </div>
           <div class="rounded-lg bg-gray-50 px-3 py-2 dark:bg-gray-800/70">
             <dt class="text-gray-500 dark:text-gray-400">Exit</dt>
@@ -117,7 +117,7 @@
           </div>
           <div class="rounded-lg bg-gray-50 px-3 py-2 dark:bg-gray-800/70">
             <dt class="text-gray-500 dark:text-gray-400">P&amp;L</dt>
-            <dd class="mt-0.5 font-semibold" :class="metricClass(chartData.trade.pnl)">{{ formatCurrency(chartData.trade.pnl) }}</dd>
+            <dd class="mt-0.5 font-semibold" :class="metricClass(chartData.trade.pnl)">{{ formatTradeCurrency(chartData.trade.pnl) }}</dd>
           </div>
           <div class="rounded-lg bg-gray-50 px-3 py-2 dark:bg-gray-800/70">
             <dt class="text-gray-500 dark:text-gray-400">Return</dt>
@@ -198,10 +198,21 @@ const intervalLabel = computed(() => {
 })
 
 // An open trade has no exit yet; say so rather than formatting a null.
+// Format in the currency the trade was actually executed in, matching the
+// Trade Details panel, rather than the account's display currency.
+const tradeCurrency = computed(() => {
+  const currency = chartData.value?.trade?.currency
+  return currency ? String(currency).toUpperCase() : currencyCode.value
+})
+
+function formatTradeCurrency(value) {
+  return formatCurrency(value, { currency: tradeCurrency.value })
+}
+
 const exitLabel = computed(() => {
   const exitPrice = chartData.value?.trade?.exitPrice
   if (exitPrice === null || exitPrice === undefined) return 'Open'
-  return formatCurrency(exitPrice)
+  return formatTradeCurrency(exitPrice)
 })
 
 // Surface a degraded chart instead of quietly rendering fallback data: a

--- a/frontend/src/utils/manualPriceKeys.js
+++ b/frontend/src/utils/manualPriceKeys.js
@@ -1,0 +1,30 @@
+// Manual option prices are stored per position. Position keys carry the
+// currency the position's stored values are in, so a key written before that
+// suffix existed no longer matches — and cleanup would delete it as unknown.
+// These helpers keep the older forms readable until they have been migrated.
+
+// The key without its currency suffix, or null when it carries none.
+export function legacyPositionKey(key) {
+  if (typeof key !== 'string' || key === '') return null
+  const separator = key.lastIndexOf('|')
+  return separator === -1 ? null : key.slice(0, separator)
+}
+
+// Read a stored price, preferring the current key, then the pre-suffix key,
+// then the oldest bare-symbol form.
+export function readManualPrice(store, key, symbol) {
+  if (!store) return undefined
+  if (store[key] !== undefined) return store[key]
+
+  const legacy = legacyPositionKey(key)
+  if (legacy !== null && store[legacy] !== undefined) return store[legacy]
+  return store[symbol]
+}
+
+// Every key that must survive a cleanup sweep for one position.
+export function liveKeysForPosition(key, symbol) {
+  const keys = [key, symbol].filter(k => typeof k === 'string' && k !== '')
+  const legacy = legacyPositionKey(key)
+  if (legacy !== null) keys.push(legacy)
+  return keys
+}

--- a/frontend/src/utils/manualPriceKeys.test.js
+++ b/frontend/src/utils/manualPriceKeys.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { legacyPositionKey, readManualPrice, liveKeysForPosition } from './manualPriceKeys'
+
+describe('legacyPositionKey', () => {
+  it('strips the currency suffix', () => {
+    expect(legacyPositionKey('MRVL_65_2026-02-20_put|USD')).toBe('MRVL_65_2026-02-20_put')
+    expect(legacyPositionKey('EXCO.DE|EUR')).toBe('EXCO.DE')
+  })
+
+  it('returns null for a key that carries no suffix', () => {
+    expect(legacyPositionKey('MRVL')).toBeNull()
+    expect(legacyPositionKey('')).toBeNull()
+    expect(legacyPositionKey(undefined)).toBeNull()
+  })
+})
+
+describe('readManualPrice', () => {
+  const key = 'MRVL_65_2026-02-20_put|USD'
+  const legacy = 'MRVL_65_2026-02-20_put'
+
+  it('prefers a value stored under the current key', () => {
+    expect(readManualPrice({ [key]: 2.5, [legacy]: 9 }, key, 'MRVL')).toBe(2.5)
+  })
+
+  it('finds a value saved before keys carried a currency', () => {
+    // The upgrade case: without this the price the user typed disappears.
+    expect(readManualPrice({ [legacy]: 2.5 }, key, 'MRVL')).toBe(2.5)
+  })
+
+  it('still finds the oldest bare-symbol form', () => {
+    expect(readManualPrice({ MRVL: 2.5 }, key, 'MRVL')).toBe(2.5)
+  })
+
+  it('returns undefined when nothing is stored', () => {
+    expect(readManualPrice({}, key, 'MRVL')).toBeUndefined()
+    expect(readManualPrice(null, key, 'MRVL')).toBeUndefined()
+  })
+})
+
+describe('liveKeysForPosition', () => {
+  it('keeps the pre-suffix key alive so cleanup cannot delete it', () => {
+    const keys = liveKeysForPosition('MRVL_65_2026-02-20_put|USD', 'MRVL')
+    expect(keys).toContain('MRVL_65_2026-02-20_put|USD')
+    expect(keys).toContain('MRVL_65_2026-02-20_put')
+    expect(keys).toContain('MRVL')
+  })
+
+  it('omits a legacy entry for a key with no suffix', () => {
+    expect(liveKeysForPosition('MRVL', 'MRVL')).toEqual(['MRVL', 'MRVL'])
+  })
+})

--- a/frontend/src/utils/positionTotals.js
+++ b/frontend/src/utils/positionTotals.js
@@ -1,0 +1,81 @@
+// Aggregating open positions is only meaningful once every value is in one
+// currency. These helpers decide what may be converted and what must be left
+// out, so a total is never assembled from mixed units or from a value that was
+// never available.
+//
+// Every check here is explicit about null. Number(null) is 0, so coercing first
+// would read a missing rate as a real one and a missing quote as a worthless
+// position.
+
+export function positionStatedCurrency(position) {
+  const currency = position?.currency
+  return currency ? String(currency).toUpperCase() : null
+}
+
+// The API sends null when it could not obtain a usable rate. A rate must be a
+// finite positive number to be worth anything: zero or negative would silently
+// erase or invert the position.
+export function positionFxRate(position) {
+  const raw = position?.fx_rate ?? position?.fxRate
+  if (raw === null || raw === undefined || raw === '') return null
+  const rate = Number(raw)
+  return Number.isFinite(rate) && rate > 0 ? rate : null
+}
+
+export function toAccountCurrency(value, position, accountCurrency) {
+  // An unavailable value is not zero: a position with no quote has no current
+  // value, and reporting one of zero would understate the total.
+  if (value === null || value === undefined || value === '') return null
+  const amount = Number(value)
+  if (!Number.isFinite(amount)) return null
+
+  const currency = positionStatedCurrency(position)
+  // No stated currency means there is nothing to convert from.
+  if (!currency) return null
+  if (currency === accountCurrency) return amount
+
+  const rate = positionFxRate(position)
+  return rate === null ? null : amount * rate
+}
+
+// Positions that cannot contribute to a total: no stated currency, or a foreign
+// currency with no usable rate.
+export function positionsMissingRate(positions, accountCurrency) {
+  return (positions || []).filter((position) => {
+    const currency = positionStatedCurrency(position)
+    if (!currency) return true
+    return currency !== accountCurrency && positionFxRate(position) === null
+  })
+}
+
+export function statedCurrencies(positions) {
+  return new Set(
+    (positions || []).map(positionStatedCurrency).filter(Boolean)
+  )
+}
+
+// A total needs a conversion note whenever any position is in a currency other
+// than the account's. An all-EUR book on a USD account qualifies just as much
+// as a mixed one, and is precisely what a "more than one currency" test misses.
+export function needsCurrencyNote(positions, accountCurrency) {
+  const currencies = statedCurrencies(positions)
+  if (currencies.size > 1) return true
+  return [...currencies].some(currency => currency !== accountCurrency)
+}
+
+// Sum `pick(position)` across positions, in the account's currency. Returns null
+// when nothing could be converted, so the caller can say so rather than print a
+// zero that looks like a real total.
+export function sumInAccountCurrency(positions, pick, accountCurrency) {
+  let total = 0
+  let hasAny = false
+
+  for (const position of positions || []) {
+    const converted = toAccountCurrency(pick(position), position, accountCurrency)
+    if (converted === null) continue
+    total += converted
+    hasAny = true
+  }
+
+  return hasAny ? total : null
+}

--- a/frontend/src/utils/positionTotals.js
+++ b/frontend/src/utils/positionTotals.js
@@ -58,6 +58,11 @@ export function statedCurrencies(positions) {
 // than the account's. An all-EUR book on a USD account qualifies just as much
 // as a mixed one, and is precisely what a "more than one currency" test misses.
 export function needsCurrencyNote(positions, accountCurrency) {
+  // A position with no stated currency is excluded from totals and makes them
+  // partial, so the note has to appear for it too — otherwise a book holding
+  // only such a position is marked partial with nothing on screen saying so.
+  if ((positions || []).some(position => !positionStatedCurrency(position))) return true
+
   const currencies = statedCurrencies(positions)
   if (currencies.size > 1) return true
   return [...currencies].some(currency => currency !== accountCurrency)

--- a/frontend/src/utils/positionTotals.test.js
+++ b/frontend/src/utils/positionTotals.test.js
@@ -81,6 +81,21 @@ describe('needsCurrencyNote', () => {
   })
 })
 
+describe('ambiguous positions and the partial note stay consistent', () => {
+  const ambiguous = { currency: null, fx_rate: null, totalCost: 100 }
+
+  it('shows the note when the only position has no stated currency', () => {
+    // totalsArePartial would otherwise be true with nothing on screen saying so.
+    expect(positionsMissingRate([ambiguous], 'USD')).toHaveLength(1)
+    expect(needsCurrencyNote([ambiguous], 'USD')).toBe(true)
+  })
+
+  it('agrees with positionsMissingRate for an all-domestic book', () => {
+    expect(positionsMissingRate([usd(), usd()], 'USD')).toHaveLength(0)
+    expect(needsCurrencyNote([usd(), usd()], 'USD')).toBe(false)
+  })
+})
+
 describe('sumInAccountCurrency', () => {
   const cost = (position) => position.totalCost
 

--- a/frontend/src/utils/positionTotals.test.js
+++ b/frontend/src/utils/positionTotals.test.js
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import {
+  positionFxRate,
+  toAccountCurrency,
+  positionsMissingRate,
+  needsCurrencyNote,
+  sumInAccountCurrency
+} from './positionTotals'
+
+const eur = (over = {}) => ({ currency: 'EUR', fx_rate: 1.5, totalCost: 100, ...over })
+const usd = (over = {}) => ({ currency: 'USD', fx_rate: 1, totalCost: 100, ...over })
+
+describe('positionFxRate', () => {
+  it('rejects a null rate rather than reading it as zero', () => {
+    expect(positionFxRate({ fx_rate: null })).toBeNull()
+    expect(positionFxRate({ fx_rate: undefined })).toBeNull()
+    expect(positionFxRate({ fx_rate: '' })).toBeNull()
+  })
+
+  it('rejects a rate that is not finite and positive', () => {
+    expect(positionFxRate({ fx_rate: 0 })).toBeNull()
+    expect(positionFxRate({ fx_rate: -1 })).toBeNull()
+    expect(positionFxRate({ fx_rate: 'abc' })).toBeNull()
+  })
+
+  it('accepts the camelCase spelling for compatibility', () => {
+    expect(positionFxRate({ fxRate: 1.5 })).toBe(1.5)
+  })
+})
+
+describe('toAccountCurrency', () => {
+  it('converts a foreign value at the supplied rate', () => {
+    expect(toAccountCurrency(100, eur(), 'USD')).toBe(150)
+  })
+
+  it('passes an account-currency value through untouched', () => {
+    expect(toAccountCurrency(100, usd(), 'USD')).toBe(100)
+  })
+
+  it('returns null for a foreign position with no rate', () => {
+    expect(toAccountCurrency(100, eur({ fx_rate: null }), 'USD')).toBeNull()
+  })
+
+  it('returns null rather than zero for an unavailable value', () => {
+    expect(toAccountCurrency(null, usd(), 'USD')).toBeNull()
+    expect(toAccountCurrency(undefined, usd(), 'USD')).toBeNull()
+  })
+
+  it('returns null when the position states no currency', () => {
+    expect(toAccountCurrency(100, { currency: null, fx_rate: 1.5 }, 'USD')).toBeNull()
+  })
+})
+
+describe('positionsMissingRate', () => {
+  it('flags a foreign position with no usable rate', () => {
+    expect(positionsMissingRate([eur({ fx_rate: null })], 'USD')).toHaveLength(1)
+    expect(positionsMissingRate([eur({ fx_rate: 0 })], 'USD')).toHaveLength(1)
+  })
+
+  it('flags a position with no stated currency', () => {
+    expect(positionsMissingRate([{ currency: null }], 'USD')).toHaveLength(1)
+  })
+
+  it('does not flag a convertible or domestic position', () => {
+    expect(positionsMissingRate([eur(), usd()], 'USD')).toHaveLength(0)
+  })
+})
+
+describe('needsCurrencyNote', () => {
+  it('is true for an all-foreign book, not just a mixed one', () => {
+    // The case a "more than one currency" test misses.
+    expect(needsCurrencyNote([eur(), eur()], 'USD')).toBe(true)
+  })
+
+  it('is true for a mixed book', () => {
+    expect(needsCurrencyNote([eur(), usd()], 'USD')).toBe(true)
+  })
+
+  it('is false when everything is already in the account currency', () => {
+    expect(needsCurrencyNote([usd(), usd()], 'USD')).toBe(false)
+  })
+})
+
+describe('sumInAccountCurrency', () => {
+  const cost = (position) => position.totalCost
+
+  it('converts before adding', () => {
+    expect(sumInAccountCurrency([eur(), usd()], cost, 'USD')).toBe(250)
+  })
+
+  it('excludes a position with no rate instead of adding it at face value', () => {
+    expect(sumInAccountCurrency([eur({ fx_rate: null }), usd()], cost, 'USD')).toBe(100)
+  })
+
+  it('returns null when nothing could be converted', () => {
+    expect(sumInAccountCurrency([eur({ fx_rate: null })], cost, 'USD')).toBeNull()
+  })
+
+  it('skips an unavailable value rather than counting it as zero', () => {
+    const positions = [usd({ currentValue: null }), usd({ currentValue: 100 })]
+    expect(sumInAccountCurrency(positions, p => p.currentValue, 'USD')).toBe(100)
+  })
+
+  it('returns null when every value is unavailable', () => {
+    const positions = [usd({ unrealizedPnL: null }), usd({ unrealizedPnL: undefined })]
+    expect(sumInAccountCurrency(positions, p => p.unrealizedPnL, 'USD')).toBeNull()
+  })
+})

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1677,6 +1677,7 @@ import {
   normalizeTradeFiltersForSharedState,
   loadTradeFiltersFromStorage
 } from '@/utils/tradeFilterState'
+import { legacyPositionKey, readManualPrice } from '@/utils/manualPriceKeys'
 import {
   positionStatedCurrency,
   positionsMissingRate,
@@ -1763,14 +1764,41 @@ function setManualOptionPrice(position, value) {
   } else {
     manualOptionPrices.value[key] = num
   }
+  const legacy = legacyOpenPositionKey(position)
+  if (legacy !== null && legacy !== key) delete manualOptionPrices.value[legacy]
   if (key !== position.symbol) {
     delete manualOptionPrices.value[position.symbol]
   }
   saveManualOptionPrices()
 }
 
+// Pure: this runs inside computed properties, so it must not write to
+// manualOptionPrices — doing so invalidates the computed that is reading it.
+// Rewriting old keys is done once by migrateManualOptionPriceKeys instead.
 function getManualOptionPrice(position) {
-  return manualOptionPrices.value[getOpenPositionKey(position)] ?? manualOptionPrices.value[position.symbol]
+  return readManualPrice(manualOptionPrices.value, getOpenPositionKey(position), position.symbol)
+}
+
+// Move values saved under a pre-currency-suffix key (or the older bare-symbol
+// form) onto the current key. Called once when positions load, never on read.
+function migrateManualOptionPriceKeys() {
+  let migrated = false
+
+  openTrades.value.filter(p => p.requires_manual_price).forEach(position => {
+    const key = getOpenPositionKey(position)
+    if (manualOptionPrices.value[key] !== undefined) return
+
+    const inherited = readManualPrice(manualOptionPrices.value, key, position.symbol)
+    if (inherited === undefined) return
+
+    manualOptionPrices.value[key] = inherited
+    const legacy = legacyOpenPositionKey(position)
+    if (legacy !== null && legacy !== key) delete manualOptionPrices.value[legacy]
+    if (key !== position.symbol) delete manualOptionPrices.value[position.symbol]
+    migrated = true
+  })
+
+  if (migrated) saveManualOptionPrices()
 }
 
 function getOptionPnL(position) {
@@ -2650,6 +2678,10 @@ function cacheOpenPositions(positions) {
   }
 }
 
+function legacyOpenPositionKey(position) {
+  return legacyPositionKey(getOpenPositionKey(position))
+}
+
 function getOpenPositionKey(position) {
   // The backend stamps a stable position_key on every position; the composite
   // fallback only covers positions cached in sessionStorage before upgrade.
@@ -2732,6 +2764,9 @@ function cleanupManualOptionPrices() {
   const validKeys = new Set()
   openTrades.value.filter(p => p.requires_manual_price).forEach(p => {
     validKeys.add(getOpenPositionKey(p))
+    // Keep the pre-suffix key alive until it has been migrated on read.
+    const legacy = legacyOpenPositionKey(p)
+    if (legacy !== null) validKeys.add(legacy)
     validKeys.add(p.symbol)
   })
   let cleaned = false
@@ -2760,6 +2795,7 @@ async function fetchOpenTrades(options = {}) {
         openPositionsAccountCurrency.value = fastResponse.data.account_currency ?? fastResponse.data.accountCurrency ?? openPositionsAccountCurrency.value
         openTrades.value = fastPositions
         cacheOpenPositions(openTrades.value)
+        migrateManualOptionPriceKeys()
         cleanupManualOptionPrices()
         fastRequestSucceeded = true
       } catch (fastError) {
@@ -2777,6 +2813,7 @@ async function fetchOpenTrades(options = {}) {
     openPositionsAccountCurrency.value = response.data.account_currency ?? response.data.accountCurrency ?? openPositionsAccountCurrency.value
     openTrades.value = response.data.positions || []
     cacheOpenPositions(openTrades.value)
+    migrateManualOptionPriceKeys()
     cleanupManualOptionPrices()
   } catch (error) {
     console.error('Failed to fetch open trades:', error)

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1677,6 +1677,12 @@ import {
   normalizeTradeFiltersForSharedState,
   loadTradeFiltersFromStorage
 } from '@/utils/tradeFilterState'
+import {
+  positionStatedCurrency,
+  positionsMissingRate,
+  needsCurrencyNote,
+  sumInAccountCurrency as sumPositionsInAccountCurrency
+} from '@/utils/positionTotals'
 import draggable from 'vuedraggable'
 
 const authStore = useAuthStore()
@@ -2317,11 +2323,10 @@ watch(
   { immediate: true }
 )
 
-// A position's own currency. Trades in one symbol share one currency, so this
-// is well defined per row; only the account default is an assumption.
+// For display only: an unlabelled row falls back to the account's currency,
+// which is a guess and must never be used to decide a conversion.
 function positionCurrency(position) {
-  const currency = position?.currency
-  return currency ? String(currency).toUpperCase() : currencyCode.value
+  return positionStatedCurrency(position) || currencyCode.value
 }
 
 function formatPositionCurrency(value, position) {
@@ -2337,43 +2342,16 @@ function formatSignedPositionCurrency(value, position) {
 // supplies a per-position rate for.
 const accountCurrency = computed(() => (openPositionsAccountCurrency.value || currencyCode.value).toUpperCase())
 
-const openPositionCurrencies = computed(
-  () => new Set(openTrades.value.map(position => positionCurrency(position)))
+const hasMixedCurrencies = computed(
+  () => needsCurrencyNote(openTrades.value, accountCurrency.value)
 )
 
-const hasMixedCurrencies = computed(() => openPositionCurrencies.value.size > 1)
-
-// A position whose rate could not be fetched must be excluded from a total
-// rather than added at face value, which would silently understate or inflate
-// it. Track them so the UI can say the total is partial.
-const positionsMissingRate = computed(() => openTrades.value.filter(position => (
-  positionCurrency(position) !== accountCurrency.value &&
-  !Number.isFinite(Number(position.fxRate))
-)))
-
-const totalsArePartial = computed(() => positionsMissingRate.value.length > 0)
-
-function toAccountCurrency(value, position) {
-  const amount = Number(value)
-  if (!Number.isFinite(amount)) return null
-  if (positionCurrency(position) === accountCurrency.value) return amount
-
-  const rate = Number(position.fxRate)
-  return Number.isFinite(rate) ? amount * rate : null
-}
+const totalsArePartial = computed(
+  () => positionsMissingRate(openTrades.value, accountCurrency.value).length > 0
+)
 
 function sumInAccountCurrency(pick) {
-  let total = 0
-  let hasAny = false
-
-  for (const position of openTrades.value) {
-    const converted = toAccountCurrency(pick(position), position)
-    if (converted === null) continue
-    total += converted
-    hasAny = true
-  }
-
-  return hasAny ? total : null
+  return sumPositionsInAccountCurrency(openTrades.value, pick, accountCurrency.value)
 }
 
 const totalOpenCostAccount = computed(() => sumInAccountCurrency(position => position.totalCost || 0))
@@ -2386,7 +2364,11 @@ const totalUnrealizedPnLAccount = computed(() => sumInAccountCurrency(position =
   position.requires_manual_price ? getOptionPnL(position).unrealizedPnL : position.unrealizedPnL
 )))
 
-const totalOpenCostLabel = computed(() => formatCurrency(totalOpenCostAccount.value ?? 0, { currency: accountCurrency.value }))
+const totalOpenCostLabel = computed(() => (
+  totalOpenCostAccount.value === null
+    ? '\u2014'
+    : formatCurrency(totalOpenCostAccount.value, { currency: accountCurrency.value })
+))
 
 const totalCurrentValueLabel = computed(() => (
   totalCurrentValueAccount.value === null
@@ -2815,7 +2797,7 @@ async function fetchOpenTrades(options = {}) {
         if (requestId !== openPositionsRequestId) return
 
         const fastPositions = preserveExistingQuoteData(fastResponse.data.positions || [])
-        openPositionsAccountCurrency.value = fastResponse.data.accountCurrency || openPositionsAccountCurrency.value
+        openPositionsAccountCurrency.value = fastResponse.data.account_currency ?? fastResponse.data.accountCurrency ?? openPositionsAccountCurrency.value
         openTrades.value = fastPositions
         cacheOpenPositions(openTrades.value)
         cleanupManualOptionPrices()
@@ -2832,7 +2814,7 @@ async function fetchOpenTrades(options = {}) {
       console.warn('Real-time quotes not available:', response.data.error)
     }
 
-    openPositionsAccountCurrency.value = response.data.accountCurrency || openPositionsAccountCurrency.value
+    openPositionsAccountCurrency.value = response.data.account_currency ?? response.data.accountCurrency ?? openPositionsAccountCurrency.value
     openTrades.value = response.data.positions || []
     cacheOpenPositions(openTrades.value)
     cleanupManualOptionPrices()

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -619,7 +619,7 @@
                     <div class="text-lg font-bold" :class="[
                       getOptionPnL(position).unrealizedPnL >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
                     ]">
-                      {{ formatSignedCurrency(getOptionPnL(position).unrealizedPnL) }}
+                      {{ formatSignedPositionCurrency(getOptionPnL(position).unrealizedPnL, position) }}
                     </div>
                     <div class="text-xs font-medium" :class="[
                       getOptionPnL(position).unrealizedPnLPercent >= 0 ? 'text-green-500' : 'text-red-500'
@@ -633,7 +633,7 @@
                   <div class="text-lg font-bold" :class="[
                     position.unrealizedPnL >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
                   ]">
-                    {{ formatSignedCurrency(position.unrealizedPnL) }}
+                    {{ formatSignedPositionCurrency(position.unrealizedPnL, position) }}
                   </div>
                   <div class="text-xs font-medium" :class="[
                     position.unrealizedPnLPercent >= 0 ? 'text-green-500' : 'text-red-500'
@@ -659,11 +659,11 @@
                 </div>
                 <div class="table-card-row">
                   <span class="table-card-label">Avg Price</span>
-                  <span class="table-card-value">{{ formatCurrency(position.avgPrice) }}</span>
+                  <span class="table-card-value">{{ formatPositionCurrency(position.avgPrice, position) }}</span>
                 </div>
                 <div class="table-card-row">
                   <span class="table-card-label">Total Cost</span>
-                  <span class="table-card-value">{{ formatCurrency(position.totalCost) }}</span>
+                  <span class="table-card-value">{{ formatPositionCurrency(position.totalCost, position) }}</span>
                 </div>
                 <div class="table-card-row">
                   <span class="table-card-label">{{ position.requires_manual_price ? 'Premium' : 'Current Price' }}<span v-if="position.quoteSource === 'alpaca'" class="ml-1 text-gray-400 font-normal">(via Alpaca)</span></span>
@@ -683,7 +683,7 @@
                       </div>
                     </template>
                     <template v-else>
-                      <span v-if="position.currentPrice !== null">{{ formatCurrency(position.currentPrice) }}</span>
+                      <span v-if="position.currentPrice !== null">{{ formatPositionCurrency(position.currentPrice, position) }}</span>
                       <span v-else class="text-xs text-gray-400">-</span>
                     </template>
                   </span>
@@ -709,7 +709,7 @@
                         {{ trade.side }}
                       </span>
                       <span class="text-xs text-gray-600 dark:text-gray-400">
-                        {{ (trade.quantity || 0).toLocaleString() }} @ {{ formatCurrency(trade.entry_price) }}
+                        {{ (trade.quantity || 0).toLocaleString() }} @ {{ formatPositionCurrency(trade.entry_price, position) }}
                       </span>
                     </div>
                     <router-link
@@ -738,12 +738,12 @@
                 <div class="text-sm font-bold text-gray-900 dark:text-white">Total Position</div>
                 <div class="text-right">
                   <div class="text-sm font-bold text-gray-900 dark:text-white">
-                    {{ formatCurrency(totalOpenCost) }}
+                    {{ totalOpenCostLabel }}
                   </div>
                   <div v-if="totalUnrealizedPnL !== null" class="text-sm font-bold" :class="[
                     totalUnrealizedPnL >= 0 ? 'text-green-600' : 'text-red-600'
                   ]">
-                    {{ formatSignedCurrency(totalUnrealizedPnL) }}
+                    {{ totalUnrealizedPnLLabel }}
                   </div>
                 </div>
               </div>
@@ -827,10 +827,10 @@
                       {{ position.totalQuantity === 0 ? 'Hedged' : (position.totalQuantity || 0).toLocaleString() }}
                     </td>
                     <td class="px-3 py-2 text-sm font-bold text-gray-900 dark:text-white text-right">
-                      {{ formatCurrency(position.avgPrice) }}
+                      {{ formatPositionCurrency(position.avgPrice, position) }}
                     </td>
                     <td class="px-3 py-2 text-sm font-bold text-gray-900 dark:text-white text-right">
-                      {{ formatCurrency(position.totalCost) }}
+                      {{ formatPositionCurrency(position.totalCost, position) }}
                     </td>
                     <td class="px-3 py-2 text-sm text-right">
                       <!-- Option: manual premium input -->
@@ -851,11 +851,11 @@
                       <!-- Stock/Future: Finnhub price -->
                       <template v-else>
                         <div v-if="position.currentPrice !== null" class="font-bold text-gray-900 dark:text-white">
-                          {{ formatCurrency(position.currentPrice) }}
+                          {{ formatPositionCurrency(position.currentPrice, position) }}
                           <div v-if="position.dayChange !== undefined" class="text-xs" :class="[
                             position.dayChange >= 0 ? 'text-green-600' : 'text-red-600'
                           ]">
-                            {{ formatSignedCurrency(position.dayChange) }}
+                            {{ formatSignedPositionCurrency(position.dayChange, position) }}
                             ({{ position.dayChangePercent >= 0 ? '+' : '' }}{{ formatNumber(position.dayChangePercent) }}%)
                           </div>
                           <div v-if="position.quoteSource === 'alpaca'" class="text-xs text-gray-400">via Alpaca</div>
@@ -866,13 +866,13 @@
                     <td class="px-3 py-2 text-sm font-bold text-right">
                       <template v-if="position.requires_manual_price">
                         <span v-if="getOptionPnL(position).currentValue !== null" class="text-gray-900 dark:text-white">
-                          {{ formatCurrency(getOptionPnL(position).currentValue) }}
+                          {{ formatPositionCurrency(getOptionPnL(position).currentValue, position) }}
                         </span>
                         <span v-else class="text-xs text-gray-400">-</span>
                       </template>
                       <template v-else>
                         <span v-if="position.currentValue !== null" class="text-gray-900 dark:text-white">
-                          {{ formatCurrency(position.currentValue) }}
+                          {{ formatPositionCurrency(position.currentValue, position) }}
                         </span>
                         <span v-else class="text-xs text-gray-400">-</span>
                       </template>
@@ -883,7 +883,7 @@
                           <div :class="[
                             getOptionPnL(position).unrealizedPnL >= 0 ? 'text-green-600' : 'text-red-600'
                           ]">
-                            {{ formatSignedCurrency(getOptionPnL(position).unrealizedPnL) }}
+                            {{ formatSignedPositionCurrency(getOptionPnL(position).unrealizedPnL, position) }}
                           </div>
                           <div class="text-xs" :class="[
                             getOptionPnL(position).unrealizedPnLPercent >= 0 ? 'text-green-500' : 'text-red-500'
@@ -898,7 +898,7 @@
                           <div :class="[
                             position.unrealizedPnL >= 0 ? 'text-green-600' : 'text-red-600'
                           ]">
-                            {{ formatSignedCurrency(position.unrealizedPnL) }}
+                            {{ formatSignedPositionCurrency(position.unrealizedPnL, position) }}
                           </div>
                           <div class="text-xs" :class="[
                             position.unrealizedPnLPercent >= 0 ? 'text-green-500' : 'text-red-500'
@@ -946,10 +946,10 @@
                       <span class="text-xs">-</span>
                     </td>
                     <td class="px-3 py-2 text-sm text-gray-700 dark:text-gray-300 text-right">
-                      {{ formatCurrency(trade.entry_price) }}
+                      {{ formatPositionCurrency(trade.entry_price, position) }}
                     </td>
                     <td class="px-3 py-2 text-sm text-gray-700 dark:text-gray-300 text-right">
-                      {{ formatCurrency(trade.entry_price * trade.quantity) }}
+                      {{ formatPositionCurrency(trade.entry_price * trade.quantity, position) }}
                     </td>
                     <td class="px-3 py-2 text-sm text-gray-400 text-right">
                       <span class="text-xs">-</span>
@@ -978,13 +978,22 @@
                 <tr>
                   <td colspan="5" class="px-3 py-3 text-sm font-bold text-gray-900 dark:text-white text-right">
                     Total:
+                    <span
+                      v-if="hasMixedCurrencies"
+                      class="ml-1 font-normal text-xs text-gray-500 dark:text-gray-400"
+                      :title="totalsArePartial
+                        ? `Converted to ${accountCurrency}; positions with no exchange rate are excluded`
+                        : `Positions converted to ${accountCurrency} at current rates`"
+                    >
+                      (in {{ accountCurrency }}<template v-if="totalsArePartial">, partial</template>)
+                    </span>
                   </td>
                   <td class="px-3 py-3 text-sm font-bold text-gray-900 dark:text-white text-right tabular-nums">
-                    {{ formatCurrency(totalOpenCost) }}
+                    {{ totalOpenCostLabel }}
                   </td>
                   <td class="px-3 py-3"></td>
                   <td class="px-3 py-3 text-sm font-bold text-gray-900 dark:text-white text-right tabular-nums">
-                    <span v-if="totalCurrentValue !== null">{{ formatCurrency(totalCurrentValue) }}</span>
+                    <span v-if="totalCurrentValueLabel">{{ totalCurrentValueLabel }}</span>
                     <span v-else class="text-xs text-gray-400">-</span>
                   </td>
                   <td class="px-3 py-3 text-sm font-bold text-right tabular-nums">
@@ -992,7 +1001,7 @@
                       <div :class="[
                         totalUnrealizedPnL >= 0 ? 'text-green-600' : 'text-red-600'
                       ]">
-                        {{ formatSignedCurrency(totalUnrealizedPnL) }}
+                        {{ totalUnrealizedPnLLabel }}
                       </div>
                       <div class="text-xs" :class="[
                         totalUnrealizedPnLPercent >= 0 ? 'text-green-500' : 'text-red-500'
@@ -1718,6 +1727,8 @@ const hasMoreOpenTrades = computed(
 const quotesLoading = ref(false) // True while Finnhub quotes are being fetched
 const analyticsLoading = ref(true) // True while analytics data is being fetched
 let openPositionsRequestId = 0
+// Base currency the API normalised the position rates against.
+const openPositionsAccountCurrency = ref(null)
 
 // Manual option price tracking (persisted in localStorage)
 const manualOptionPrices = ref({})
@@ -2306,6 +2317,89 @@ watch(
   { immediate: true }
 )
 
+// A position's own currency. Trades in one symbol share one currency, so this
+// is well defined per row; only the account default is an assumption.
+function positionCurrency(position) {
+  const currency = position?.currency
+  return currency ? String(currency).toUpperCase() : currencyCode.value
+}
+
+function formatPositionCurrency(value, position) {
+  return formatCurrency(value, { currency: positionCurrency(position) })
+}
+
+function formatSignedPositionCurrency(value, position) {
+  return formatSignedCurrency(value, { currency: positionCurrency(position) })
+}
+
+// Individual positions display in their own currency; aggregates only mean
+// something once normalised into the account's base currency, which the API
+// supplies a per-position rate for.
+const accountCurrency = computed(() => (openPositionsAccountCurrency.value || currencyCode.value).toUpperCase())
+
+const openPositionCurrencies = computed(
+  () => new Set(openTrades.value.map(position => positionCurrency(position)))
+)
+
+const hasMixedCurrencies = computed(() => openPositionCurrencies.value.size > 1)
+
+// A position whose rate could not be fetched must be excluded from a total
+// rather than added at face value, which would silently understate or inflate
+// it. Track them so the UI can say the total is partial.
+const positionsMissingRate = computed(() => openTrades.value.filter(position => (
+  positionCurrency(position) !== accountCurrency.value &&
+  !Number.isFinite(Number(position.fxRate))
+)))
+
+const totalsArePartial = computed(() => positionsMissingRate.value.length > 0)
+
+function toAccountCurrency(value, position) {
+  const amount = Number(value)
+  if (!Number.isFinite(amount)) return null
+  if (positionCurrency(position) === accountCurrency.value) return amount
+
+  const rate = Number(position.fxRate)
+  return Number.isFinite(rate) ? amount * rate : null
+}
+
+function sumInAccountCurrency(pick) {
+  let total = 0
+  let hasAny = false
+
+  for (const position of openTrades.value) {
+    const converted = toAccountCurrency(pick(position), position)
+    if (converted === null) continue
+    total += converted
+    hasAny = true
+  }
+
+  return hasAny ? total : null
+}
+
+const totalOpenCostAccount = computed(() => sumInAccountCurrency(position => position.totalCost || 0))
+
+const totalCurrentValueAccount = computed(() => sumInAccountCurrency(position => (
+  position.requires_manual_price ? getOptionPnL(position).currentValue : position.currentValue
+)))
+
+const totalUnrealizedPnLAccount = computed(() => sumInAccountCurrency(position => (
+  position.requires_manual_price ? getOptionPnL(position).unrealizedPnL : position.unrealizedPnL
+)))
+
+const totalOpenCostLabel = computed(() => formatCurrency(totalOpenCostAccount.value ?? 0, { currency: accountCurrency.value }))
+
+const totalCurrentValueLabel = computed(() => (
+  totalCurrentValueAccount.value === null
+    ? null
+    : formatCurrency(totalCurrentValueAccount.value, { currency: accountCurrency.value })
+))
+
+const totalUnrealizedPnLLabel = computed(() => (
+  totalUnrealizedPnLAccount.value === null
+    ? null
+    : formatSignedCurrency(totalUnrealizedPnLAccount.value, { currency: accountCurrency.value })
+))
+
 const totalOpenCost = computed(() => {
   return openTrades.value.reduce((sum, position) => sum + (position.totalCost || 0), 0)
 })
@@ -2347,8 +2441,12 @@ const totalCurrentValue = computed(() => {
 })
 
 const totalUnrealizedPnLPercent = computed(() => {
-  if (totalUnrealizedPnL.value === null || totalOpenCost.value === 0) return 0
-  return (totalUnrealizedPnL.value / totalOpenCost.value) * 100
+  // Both sides are normalised to the account currency, so this ratio is
+  // meaningful even for a book held across several currencies.
+  const pnl = totalUnrealizedPnLAccount.value
+  const cost = totalOpenCostAccount.value
+  if (pnl === null || !cost) return 0
+  return (pnl / cost) * 100
 })
 
 const computedWinRate = computed(() => {
@@ -2717,6 +2815,7 @@ async function fetchOpenTrades(options = {}) {
         if (requestId !== openPositionsRequestId) return
 
         const fastPositions = preserveExistingQuoteData(fastResponse.data.positions || [])
+        openPositionsAccountCurrency.value = fastResponse.data.accountCurrency || openPositionsAccountCurrency.value
         openTrades.value = fastPositions
         cacheOpenPositions(openTrades.value)
         cleanupManualOptionPrices()
@@ -2733,6 +2832,7 @@ async function fetchOpenTrades(options = {}) {
       console.warn('Real-time quotes not available:', response.data.error)
     }
 
+    openPositionsAccountCurrency.value = response.data.accountCurrency || openPositionsAccountCurrency.value
     openTrades.value = response.data.positions || []
     cacheOpenPositions(openTrades.value)
     cleanupManualOptionPrices()

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -740,8 +740,8 @@
                   <div class="text-sm font-bold text-gray-900 dark:text-white">
                     {{ totalOpenCostLabel }}
                   </div>
-                  <div v-if="totalUnrealizedPnL !== null" class="text-sm font-bold" :class="[
-                    totalUnrealizedPnL >= 0 ? 'text-green-600' : 'text-red-600'
+                  <div v-if="totalUnrealizedPnLAccount !== null" class="text-sm font-bold" :class="[
+                    totalUnrealizedPnLAccount >= 0 ? 'text-green-600' : 'text-red-600'
                   ]">
                     {{ totalUnrealizedPnLLabel }}
                   </div>
@@ -997,9 +997,9 @@
                     <span v-else class="text-xs text-gray-400">-</span>
                   </td>
                   <td class="px-3 py-3 text-sm font-bold text-right tabular-nums">
-                    <div v-if="totalUnrealizedPnL !== null">
+                    <div v-if="totalUnrealizedPnLAccount !== null">
                       <div :class="[
-                        totalUnrealizedPnL >= 0 ? 'text-green-600' : 'text-red-600'
+                        totalUnrealizedPnLAccount >= 0 ? 'text-green-600' : 'text-red-600'
                       ]">
                         {{ totalUnrealizedPnLLabel }}
                       </div>
@@ -2381,46 +2381,6 @@ const totalUnrealizedPnLLabel = computed(() => (
     ? null
     : formatSignedCurrency(totalUnrealizedPnLAccount.value, { currency: accountCurrency.value })
 ))
-
-const totalOpenCost = computed(() => {
-  return openTrades.value.reduce((sum, position) => sum + (position.totalCost || 0), 0)
-})
-
-const totalUnrealizedPnL = computed(() => {
-  let total = 0
-  let hasAny = false
-  openTrades.value.forEach(position => {
-    if (position.requires_manual_price) {
-      const optPnL = getOptionPnL(position)
-      if (optPnL.unrealizedPnL !== null) {
-        total += optPnL.unrealizedPnL
-        hasAny = true
-      }
-    } else if (position.unrealizedPnL !== null) {
-      total += position.unrealizedPnL
-      hasAny = true
-    }
-  })
-  return hasAny ? total : null
-})
-
-const totalCurrentValue = computed(() => {
-  let total = 0
-  let hasAny = false
-  openTrades.value.forEach(position => {
-    if (position.requires_manual_price) {
-      const optPnL = getOptionPnL(position)
-      if (optPnL.currentValue !== null) {
-        total += optPnL.currentValue
-        hasAny = true
-      }
-    } else if (position.currentValue !== null) {
-      total += position.currentValue
-      hasAny = true
-    }
-  })
-  return hasAny ? total : null
-})
 
 const totalUnrealizedPnLPercent = computed(() => {
   // Both sides are normalised to the account currency, so this ratio is


### PR DESCRIPTION
Open positions were wrong for any book that is not entirely USD.

- Finnhub's free tier will not quote non-US symbols, leaving those positions with no price and no unrealized P&L; they now fall through to Yahoo, shaped like the Finnhub quote callers already consume
- Quotes arrive in the instrument's currency, not the one the position is booked in; restate before deriving value, drop if unconvertible
- Yahoo quotes UK listings in pence ("GBp"/"GBX"); divide the minor unit out before applying any rate
- findOpenPositionsByUser did not select original_currency, so a EUR holding was labelled with a dollar sign
- Totals summed across currencies; rows now render natively, only aggregates convert, and a position with no rate is excluded and the total marked partial

Uses the current rate, which is right for current value and unrealized P&L. Realized history should use exchange_rate at execution; untouched.