### PR TITLE
fix(mae): take excursion candles from the dispatched method

### DIFF
--- a/backend/src/utils/maeEstimator.js
+++ b/backend/src/utils/maeEstimator.js
@@ -365,7 +365,7 @@ class MAEEstimator {
     const resolution = this.getResolutionForTrade(startTime, endTime);
     const from = Math.floor(new Date(startTime).getTime() / 1000);
     const to = Math.floor(new Date(endTime).getTime() / 1000);
-    return finnhub.getCandles(trade.symbol, resolution, from, to);
+    return finnhub.getStockCandles(trade.symbol, resolution, from, to);
   }
 
   /**


### PR DESCRIPTION
MAE/MFE and post-exit excursions never populated on a free tier that gates /stock/candle, while charts and replay worked on the same instance: maeEstimator called getCandles, which hits the endpoint directly and bypasses the provider dispatcher.

getStockCandles dispatches, so it inherits whatever fallbacks the instance has configured. The two differ only in return shape, and normalizeCandles already accepts both.

One deliberate behavioural difference: getCandles maps a CUSIP-looking symbol to a ticker first. Trades reach this point with a resolved symbol, so nothing is lost — but a CUSIP left in `symbol` would now fail to resolve rather than be rescued.