### PR TITLE
fix(identity): give non-US holdings a name, a logo and an industry

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Free, open-source deployment with all Pro features included. Perfect for:
 
 **Note**: For full feature access (real-time quotes, advanced charts, sector analysis), a [Finnhub.io Basic plan](https://finnhub.io/pricing) is required. Free tier available with limitations.
 
+**Logo fallbacks**: the logo fallbacks send ticker requests directly from the
+browser to Parqet and FMP.
+
 ## Technology Stack
 
 **Backend**: Node.js, Express, PostgreSQL

--- a/backend/src/controllers/symbols.controller.js
+++ b/backend/src/controllers/symbols.controller.js
@@ -2,6 +2,8 @@ const db = require('../config/database');
 const finnhub = require('../utils/finnhub');
 const cache = require('../utils/cache');
 const symbolCategories = require('../utils/symbolCategories');
+const yahooFinance = require('../utils/yahooFinance');
+const TierService = require('../services/tierService');
 const asyncHandler = require('../utils/asyncHandler');
 const AppError = require('../utils/AppError');
 
@@ -278,6 +280,33 @@ async function getSymbolMetadata(req, res) {
           exchange: metadata[symbol].exchange || category.exchange || null,
           logo: metadata[symbol].logo || category.logo || null
         };
+      }
+    }
+
+    // Yahoo needs no key and covers listings the configured provider may not.
+    // Self-hosted only, matching the gate the chart fallbacks use: a hosted
+    // instance must never reach this provider. Best-effort either way — a
+    // failure here must not fail the response.
+    const billingEnabled = await TierService.isBillingEnabled(req.headers?.host);
+    const symbolsMissingName = billingEnabled ? [] : symbols.filter(
+      symbol => metadata[symbol] && !metadata[symbol].companyName && !isOptionContractSymbol(symbol)
+    );
+
+    if (symbolsMissingName.length > 0 && yahooFinance.isEnabled()) {
+      // Bounded concurrency: a portfolio of uncovered symbols would otherwise
+      // open one request per symbol at once.
+      const chunkSize = 5;
+      for (let i = 0; i < symbolsMissingName.length; i += chunkSize) {
+        const chunk = symbolsMissingName.slice(i, i + chunkSize);
+        const names = await Promise.all(
+          chunk.map(symbol => yahooFinance.getSymbolName(symbol).catch(() => null))
+        );
+
+        chunk.forEach((symbol, index) => {
+          if (names[index]) {
+            metadata[symbol] = { ...metadata[symbol], companyName: names[index] };
+          }
+        });
       }
     }
 

--- a/backend/src/controllers/symbols.controller.js
+++ b/backend/src/controllers/symbols.controller.js
@@ -4,6 +4,7 @@ const cache = require('../utils/cache');
 const symbolCategories = require('../utils/symbolCategories');
 const yahooFinance = require('../utils/yahooFinance');
 const TierService = require('../services/tierService');
+const { isOptionContractSymbol } = require('../utils/optionSymbol');
 const asyncHandler = require('../utils/asyncHandler');
 const AppError = require('../utils/AppError');
 
@@ -36,11 +37,6 @@ function applyCategoryMetadata(target, category) {
     exchange: target.exchange || category.exchange || null,
     logo: target.logo || category.logo || null
   };
-}
-
-function isOptionContractSymbol(symbol) {
-  const compact = String(symbol || '').toUpperCase().replace(/\s+/g, '');
-  return /^[A-Z]{1,6}\d{6}[CP]\d{8}$/.test(compact);
 }
 
 function isSupportedProviderResult(item) {
@@ -205,6 +201,36 @@ async function searchSymbols(req, res) {
   }
 }
 
+// Self-hosted only, matching the gate the chart fallbacks use.
+async function backfillCompanyNames(metadata, symbols, hostHeader) {
+  if (await TierService.isBillingEnabled(hostHeader)) {
+    return;
+  }
+
+  if (!yahooFinance.isEnabled()) {
+    return;
+  }
+
+  const symbolsMissingName = symbols.filter(
+    symbol => metadata[symbol] && !metadata[symbol].companyName && !isOptionContractSymbol(symbol)
+  );
+
+  // Bounded concurrency: one request per symbol at once would be worse.
+  const chunkSize = 5;
+  for (let i = 0; i < symbolsMissingName.length; i += chunkSize) {
+    const chunk = symbolsMissingName.slice(i, i + chunkSize);
+    const names = await Promise.all(
+      chunk.map(symbol => yahooFinance.getSymbolName(symbol).catch(() => null))
+    );
+
+    chunk.forEach((symbol, index) => {
+      if (names[index]) {
+        metadata[symbol] = { ...metadata[symbol], companyName: names[index] };
+      }
+    });
+  }
+}
+
 async function getSymbolMetadata(req, res) {
   try {
     const symbols = normalizeSymbolsParam(req.query.symbols);
@@ -283,31 +309,11 @@ async function getSymbolMetadata(req, res) {
       }
     }
 
-    // Yahoo needs no key and covers listings the configured provider may not.
-    // Self-hosted only, matching the gate the chart fallbacks use: a hosted
-    // instance must never reach this provider. Best-effort either way — a
-    // failure here must not fail the response.
-    const billingEnabled = await TierService.isBillingEnabled(req.headers?.host);
-    const symbolsMissingName = billingEnabled ? [] : symbols.filter(
-      symbol => metadata[symbol] && !metadata[symbol].companyName && !isOptionContractSymbol(symbol)
-    );
-
-    if (symbolsMissingName.length > 0 && yahooFinance.isEnabled()) {
-      // Bounded concurrency: a portfolio of uncovered symbols would otherwise
-      // open one request per symbol at once.
-      const chunkSize = 5;
-      for (let i = 0; i < symbolsMissingName.length; i += chunkSize) {
-        const chunk = symbolsMissingName.slice(i, i + chunkSize);
-        const names = await Promise.all(
-          chunk.map(symbol => yahooFinance.getSymbolName(symbol).catch(() => null))
-        );
-
-        chunk.forEach((symbol, index) => {
-          if (names[index]) {
-            metadata[symbol] = { ...metadata[symbol], companyName: names[index] };
-          }
-        });
-      }
+    // Best-effort: a name is a nicety and must not fail the response.
+    try {
+      await backfillCompanyNames(metadata, symbols, req.headers?.host);
+    } catch (fallbackError) {
+      console.warn(`[SYMBOLS] Name fallback skipped: ${fallbackError.message}`);
     }
 
     cache.set(cacheKey, metadata, CACHE_TTL);

--- a/backend/src/utils/cache.js
+++ b/backend/src/utils/cache.js
@@ -48,7 +48,9 @@ const NAMESPACE_TTLS = {
   chart_daily: HOUR,
   yahoo_chart_intraday: 15 * MINUTE,
   yahoo_chart_daily: HOUR,
-  yahoo_quote: 2 * MINUTE
+  yahoo_symbol_name: DAY,
+  yahoo_quote: 2 * MINUTE,
+  yahoo_symbol_profile: DAY
 };
 
 const SWEEP_INTERVAL_MS = MINUTE;

--- a/backend/src/utils/optionSymbol.js
+++ b/backend/src/utils/optionSymbol.js
@@ -1,0 +1,7 @@
+// OCC contract symbols, e.g. SPY   260618P00350000.
+function isOptionContractSymbol(symbol) {
+  const compact = String(symbol || '').toUpperCase().replace(/\s+/g, '');
+  return /^[A-Z]{1,6}\d{6}[CP]\d{8}$/.test(compact);
+}
+
+module.exports = { isOptionContractSymbol };

--- a/backend/src/utils/symbolCategories.js
+++ b/backend/src/utils/symbolCategories.js
@@ -1,5 +1,7 @@
 const db = require('../config/database');
 const finnhub = require('./finnhub');
+const yahooFinance = require('./yahooFinance');
+const TierService = require('../services/tierService');
 const cache = require('./cache');
 
 class SymbolCategoryManager {
@@ -97,8 +99,33 @@ class SymbolCategoryManager {
       
       // If not found or stale, fetch from API
         console.log(`[CHECK] Fetching category for ${symbol} from API...`);
-        const profile = await finnhub.getCompanyProfile(symbolUpper);
-      
+        // A plan restriction throws rather than returning empty; degrade to
+        // the fallback below rather than abandoning the symbol.
+        let profile = null;
+        try {
+          profile = await finnhub.getCompanyProfile(symbolUpper);
+        } catch (providerError) {
+          console.warn(`[SYMBOLS] ${finnhub.displayName || 'Market data'} profile unavailable for ${symbolUpper}: ${providerError.message}`);
+        }
+
+        // Yahoo needs no key and covers listings the configured provider may not.
+        // Self-hosted only, matching the gate the chart fallbacks use.
+        const billingEnabled = await TierService.isBillingEnabled();
+        if (!billingEnabled
+            && !this.hasStoredMetadata(this.normalizeCategory(symbolUpper, profile || {}))) {
+          const yahooProfile = await yahooFinance.getSymbolProfile(symbolUpper).catch(() => null);
+
+          if (yahooProfile && (yahooProfile.name || yahooProfile.industry)) {
+            profile = {
+              ...(profile || {}),
+              name: (profile && profile.name) || yahooProfile.name,
+              finnhubIndustry: (profile && (profile.finnhubIndustry || profile.finnhub_industry))
+                || yahooProfile.industry,
+              exchange: (profile && profile.exchange) || yahooProfile.exchange
+            };
+          }
+        }
+
         if (profile) {
         // Store in permanent storage even if no industry (to avoid repeated API calls)
           await this.saveSymbolCategory(symbolUpper, profile);

--- a/backend/src/utils/symbolCategories.js
+++ b/backend/src/utils/symbolCategories.js
@@ -2,6 +2,7 @@ const db = require('../config/database');
 const finnhub = require('./finnhub');
 const yahooFinance = require('./yahooFinance');
 const TierService = require('../services/tierService');
+const { isOptionContractSymbol } = require('./optionSymbol');
 const cache = require('./cache');
 
 class SymbolCategoryManager {
@@ -99,8 +100,7 @@ class SymbolCategoryManager {
       
       // If not found or stale, fetch from API
         console.log(`[CHECK] Fetching category for ${symbol} from API...`);
-        // A plan restriction throws rather than returning empty; degrade to
-        // the fallback below rather than abandoning the symbol.
+        // A plan restriction throws rather than returning empty.
         let profile = null;
         try {
           profile = await finnhub.getCompanyProfile(symbolUpper);
@@ -108,10 +108,16 @@ class SymbolCategoryManager {
           console.warn(`[SYMBOLS] ${finnhub.displayName || 'Market data'} profile unavailable for ${symbolUpper}: ${providerError.message}`);
         }
 
-        // Yahoo needs no key and covers listings the configured provider may not.
-        // Self-hosted only, matching the gate the chart fallbacks use.
-        const billingEnabled = await TierService.isBillingEnabled();
+        // Self-hosted only. An unclassified instance is treated as hosted.
+        let billingEnabled = true;
+        try {
+          billingEnabled = await TierService.isBillingEnabled();
+        } catch (tierError) {
+          console.warn(`[SYMBOLS] Billing check failed for ${symbolUpper}, skipping name fallback: ${tierError.message}`);
+        }
+
         if (!billingEnabled
+            && !isOptionContractSymbol(symbolUpper)
             && !this.hasStoredMetadata(this.normalizeCategory(symbolUpper, profile || {}))) {
           const yahooProfile = await yahooFinance.getSymbolProfile(symbolUpper).catch(() => null);
 

--- a/backend/src/utils/yahooFinance.js
+++ b/backend/src/utils/yahooFinance.js
@@ -404,6 +404,92 @@ class YahooFinanceClient {
     }
   }
 
+  // Company profile for a listing the configured provider does not cover.
+  // Uses the search endpoint, which needs no key and no crumb, unlike
+  // quoteSummary. Search is fuzzy, so only an exact ticker match is accepted.
+  async getSymbolProfile(symbol) {
+    if (!this.isEnabled()) return null;
+
+    const yahooSymbol = this.getYahooSymbol(symbol);
+    if (!yahooSymbol) return null;
+
+    const cached = await cache.get('yahoo_symbol_profile', yahooSymbol);
+    if (cached) return cached.miss ? null : cached;
+
+    try {
+      const response = await axios.get(
+        `https://${YAHOO_CHART_HOSTS[1]}/v1/finance/search`,
+        {
+          timeout: 8000,
+          headers: { Accept: 'application/json', 'User-Agent': USER_AGENT },
+          params: { q: yahooSymbol, quotesCount: 5, newsCount: 0, enableFuzzyQuery: false }
+        }
+      );
+
+      // Search is a fuzzy endpoint: only an exact ticker match may be trusted,
+      // or a mistyped symbol silently adopts a neighbour's industry.
+      const match = (response.data?.quotes || []).find(
+        (candidate) => String(candidate?.symbol || '').toUpperCase() === yahooSymbol
+      );
+      if (!match) {
+        await cache.set('yahoo_symbol_profile', yahooSymbol, { miss: true });
+        return null;
+      }
+
+      const profile = {
+        symbol: yahooSymbol,
+        name: match.longname || match.shortname || null,
+        // An ETF legitimately has no industry; null is the right answer, not a gap.
+        industry: match.industry || null,
+        exchange: match.exchDisp || match.exchange || null,
+        quoteType: match.quoteType || null
+      };
+
+      if (profile.name || profile.industry) {
+        await cache.set('yahoo_symbol_profile', yahooSymbol, profile);
+      } else {
+        await cache.set('yahoo_symbol_profile', yahooSymbol, { miss: true });
+      }
+
+      return profile;
+    } catch (error) {
+      console.warn(`[SYMBOLS] Yahoo Finance profile lookup failed for ${yahooSymbol}: ${error.message}`);
+      return null;
+    }
+  }
+
+  // Company name for a listing the configured provider does not cover. Finnhub's
+  // free tier is US-only, so a European holding otherwise shows no name at all.
+  // The chart endpoint already carries it, so this costs one cached request.
+  async getSymbolName(symbol) {
+    if (!this.isEnabled()) return null;
+
+    const yahooSymbol = this.getYahooSymbol(symbol);
+    if (!yahooSymbol) return null;
+
+    const cached = await cache.get('yahoo_symbol_name', yahooSymbol);
+    if (cached) return cached;
+
+    try {
+      const response = await axios.get(
+        `https://${YAHOO_CHART_HOSTS[0]}/v8/finance/chart/${encodeURIComponent(yahooSymbol)}`,
+        {
+          timeout: 8000,
+          headers: { Accept: 'application/json', 'User-Agent': USER_AGENT },
+          params: { interval: '1d', range: '1d' }
+        }
+      );
+
+      const meta = response.data?.chart?.result?.[0]?.meta;
+      const name = meta?.longName || meta?.shortName || null;
+      if (name) await cache.set('yahoo_symbol_name', yahooSymbol, name);
+      return name;
+    } catch (error) {
+      console.warn(`[SYMBOLS] Yahoo Finance name lookup failed for ${yahooSymbol}: ${error.message}`);
+      return null;
+    }
+  }
+
   async getStockTradeChartData(symbol, entryDate, exitDate = null, requestedResolution = 'D') {
     if (!this.isEnabled()) {
       throw new Error('Yahoo Finance fallback is disabled');

--- a/backend/src/utils/yahooFinance.js
+++ b/backend/src/utils/yahooFinance.js
@@ -404,9 +404,7 @@ class YahooFinanceClient {
     }
   }
 
-  // Company profile for a listing the configured provider does not cover.
-  // Uses the search endpoint, which needs no key and no crumb, unlike
-  // quoteSummary. Search is fuzzy, so only an exact ticker match is accepted.
+  // Search needs no crumb, unlike quoteSummary, but is fuzzy.
   async getSymbolProfile(symbol) {
     if (!this.isEnabled()) return null;
 
@@ -426,8 +424,7 @@ class YahooFinanceClient {
         }
       );
 
-      // Search is a fuzzy endpoint: only an exact ticker match may be trusted,
-      // or a mistyped symbol silently adopts a neighbour's industry.
+      // Exact match only, or a symbol adopts a neighbour's industry.
       const match = (response.data?.quotes || []).find(
         (candidate) => String(candidate?.symbol || '').toUpperCase() === yahooSymbol
       );
@@ -439,7 +436,7 @@ class YahooFinanceClient {
       const profile = {
         symbol: yahooSymbol,
         name: match.longname || match.shortname || null,
-        // An ETF legitimately has no industry; null is the right answer, not a gap.
+        // An ETF legitimately has none.
         industry: match.industry || null,
         exchange: match.exchDisp || match.exchange || null,
         quoteType: match.quoteType || null
@@ -458,9 +455,7 @@ class YahooFinanceClient {
     }
   }
 
-  // Company name for a listing the configured provider does not cover. Finnhub's
-  // free tier is US-only, so a European holding otherwise shows no name at all.
-  // The chart endpoint already carries it, so this costs one cached request.
+  // The chart endpoint already carries the name, so this is one cached request.
   async getSymbolName(symbol) {
     if (!this.isEnabled()) return null;
 
@@ -468,7 +463,7 @@ class YahooFinanceClient {
     if (!yahooSymbol) return null;
 
     const cached = await cache.get('yahoo_symbol_name', yahooSymbol);
-    if (cached) return cached;
+    if (cached) return cached.miss ? null : cached;
 
     try {
       const response = await axios.get(
@@ -482,7 +477,7 @@ class YahooFinanceClient {
 
       const meta = response.data?.chart?.result?.[0]?.meta;
       const name = meta?.longName || meta?.shortName || null;
-      if (name) await cache.set('yahoo_symbol_name', yahooSymbol, name);
+      await cache.set('yahoo_symbol_name', yahooSymbol, name || { miss: true });
       return name;
     } catch (error) {
       console.warn(`[SYMBOLS] Yahoo Finance name lookup failed for ${yahooSymbol}: ${error.message}`);

--- a/backend/tests/controllers/symbols.metadata.fallback.test.js
+++ b/backend/tests/controllers/symbols.metadata.fallback.test.js
@@ -1,0 +1,150 @@
+jest.mock('../../src/config/database', () => ({ query: jest.fn() }));
+jest.mock('../../src/utils/finnhub', () => ({ getCompanyProfile: jest.fn() }));
+jest.mock('../../src/utils/symbolCategories', () => ({ getSymbolCategories: jest.fn() }));
+jest.mock('../../src/utils/yahooFinance', () => ({
+  isEnabled: jest.fn(() => true),
+  getSymbolName: jest.fn()
+}));
+jest.mock('../../src/services/tierService', () => ({ isBillingEnabled: jest.fn() }));
+jest.mock('../../src/utils/cache', () => ({ get: jest.fn(() => null), set: jest.fn() }));
+
+const db = require('../../src/config/database');
+const symbolCategories = require('../../src/utils/symbolCategories');
+const yahooFinance = require('../../src/utils/yahooFinance');
+const TierService = require('../../src/services/tierService');
+const symbolsController = require('../../src/controllers/symbols.controller');
+
+function createRequest(symbols, host = 'journal.example.internal') {
+  return { query: { symbols }, headers: { host } };
+}
+
+function createResponse() {
+  return {
+    statusCode: 200,
+    payload: null,
+    status(code) { this.statusCode = code; return this; },
+    json(body) { this.payload = body; return this; }
+  };
+}
+
+async function getMetadata(req) {
+  const res = createResponse();
+  await symbolsController.getSymbolMetadata(req, res, (error) => { if (error) throw error; });
+  return res;
+}
+
+describe('symbol metadata name fallback', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    db.query.mockResolvedValue({ rows: [] });
+    symbolCategories.getSymbolCategories.mockResolvedValue(new Map());
+    yahooFinance.isEnabled.mockReturnValue(true);
+    TierService.isBillingEnabled.mockResolvedValue(false);
+  });
+
+  test('backfills a name on a self-hosted instance', async () => {
+    yahooFinance.getSymbolName.mockResolvedValue('Example Company AG');
+
+    const res = await getMetadata(createRequest('EXCO.DE'));
+
+    expect(yahooFinance.getSymbolName).toHaveBeenCalledWith('EXCO.DE');
+    expect(res.payload.metadata['EXCO.DE'].companyName).toBe('Example Company AG');
+  });
+
+  test('does not call Yahoo when billing is enabled', async () => {
+    TierService.isBillingEnabled.mockResolvedValue(true);
+
+    const res = await getMetadata(createRequest('EXCO.DE', 'tradetally.io'));
+
+    expect(yahooFinance.getSymbolName).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+    expect(res.payload.metadata['EXCO.DE'].companyName).toBeNull();
+  });
+
+  test('does not call Yahoo when the fallback is disabled', async () => {
+    yahooFinance.isEnabled.mockReturnValue(false);
+
+    const res = await getMetadata(createRequest('EXCO.DE'));
+
+    expect(yahooFinance.getSymbolName).not.toHaveBeenCalled();
+    expect(res.payload.metadata['EXCO.DE'].companyName).toBeNull();
+  });
+
+  test('skips the fallback rather than failing when the billing check throws', async () => {
+    TierService.isBillingEnabled.mockRejectedValue(new Error('instance_config unavailable'));
+
+    const res = await getMetadata(createRequest('EXCO.DE'));
+
+    expect(yahooFinance.getSymbolName).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+    expect(res.payload.metadata['EXCO.DE'].companyName).toBeNull();
+  });
+
+  test('returns the response when the provider call fails', async () => {
+    yahooFinance.getSymbolName.mockRejectedValue(new Error('network down'));
+
+    const res = await getMetadata(createRequest('EXCO.DE'));
+
+    expect(res.statusCode).toBe(200);
+    expect(res.payload.metadata['EXCO.DE']).toEqual({
+      symbol: 'EXCO.DE', companyName: null, exchange: null, logo: null
+    });
+  });
+
+  test('one symbol failing does not cost the others their name', async () => {
+    yahooFinance.getSymbolName.mockImplementation(async (symbol) => {
+      if (symbol === 'BAD.DE') throw new Error('network down');
+      return `${symbol} plc`;
+    });
+
+    const res = await getMetadata(createRequest('BAD.DE,EXCO.L'));
+
+    expect(res.payload.metadata['BAD.DE'].companyName).toBeNull();
+    expect(res.payload.metadata['EXCO.L'].companyName).toBe('EXCO.L plc');
+  });
+
+  test('leaves a symbol alone when the provider knows no name', async () => {
+    yahooFinance.getSymbolName.mockResolvedValue(null);
+
+    const res = await getMetadata(createRequest('EXCO.DE'));
+
+    expect(res.payload.metadata['EXCO.DE'].companyName).toBeNull();
+  });
+
+  test('does not spend a request on an option contract symbol', async () => {
+    yahooFinance.getSymbolName.mockResolvedValue('Should not be asked');
+
+    await getMetadata(createRequest('SPY   260618P00350000'));
+
+    expect(yahooFinance.getSymbolName).not.toHaveBeenCalled();
+  });
+
+  test('does not re-query a symbol that already has a name', async () => {
+    db.query.mockResolvedValue({
+      rows: [{ symbol: 'AAPL', company_name: 'Apple Inc', exchange: 'NASDAQ', logo: 'https://logo.example/aapl.png' }]
+    });
+
+    const res = await getMetadata(createRequest('AAPL'));
+
+    expect(yahooFinance.getSymbolName).not.toHaveBeenCalled();
+    expect(res.payload.metadata.AAPL.companyName).toBe('Apple Inc');
+  });
+
+  test('requests in bounded batches rather than one call per symbol at once', async () => {
+    const symbols = Array.from({ length: 12 }, (_, i) => `SYM${i}.L`);
+    let inFlight = 0;
+    let peakInFlight = 0;
+    yahooFinance.getSymbolName.mockImplementation(async () => {
+      inFlight += 1;
+      peakInFlight = Math.max(peakInFlight, inFlight);
+      await new Promise(resolve => setImmediate(resolve));
+      inFlight -= 1;
+      return null;
+    });
+
+    await getMetadata(createRequest(symbols.join(',')));
+
+    expect(yahooFinance.getSymbolName).toHaveBeenCalledTimes(12);
+    expect(peakInFlight).toBeLessThanOrEqual(5);
+  });
+});

--- a/backend/tests/utils/symbolCategories.fallback.test.js
+++ b/backend/tests/utils/symbolCategories.fallback.test.js
@@ -1,0 +1,159 @@
+jest.mock('../../src/config/database', () => ({ query: jest.fn() }));
+jest.mock('../../src/utils/finnhub', () => ({
+  getCompanyProfile: jest.fn(),
+  displayName: 'Finnhub'
+}));
+jest.mock('../../src/utils/yahooFinance', () => ({
+  isEnabled: jest.fn(() => true),
+  getSymbolProfile: jest.fn()
+}));
+jest.mock('../../src/services/tierService', () => ({ isBillingEnabled: jest.fn() }));
+jest.mock('../../src/utils/cache', () => ({ get: jest.fn(() => null), set: jest.fn(), del: jest.fn(), data: {} }));
+
+const db = require('../../src/config/database');
+const finnhub = require('../../src/utils/finnhub');
+const yahooFinance = require('../../src/utils/yahooFinance');
+const TierService = require('../../src/services/tierService');
+const symbolCategories = require('../../src/utils/symbolCategories');
+
+function storedRows(rows) {
+  db.query.mockImplementation(async (sql) => (
+    sql.includes('SELECT') ? { rows } : { rows: [] }
+  ));
+}
+
+function planRestriction() {
+  return Object.assign(new Error('You do not have access to this resource'), { status: 403 });
+}
+
+describe('symbol category provider fallback', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    storedRows([]);
+    yahooFinance.isEnabled.mockReturnValue(true);
+    TierService.isBillingEnabled.mockResolvedValue(false);
+    yahooFinance.getSymbolProfile.mockResolvedValue(null);
+  });
+
+  test('a plan restriction no longer abandons the symbol', async () => {
+    finnhub.getCompanyProfile.mockRejectedValue(planRestriction());
+    yahooFinance.getSymbolProfile.mockResolvedValue({
+      symbol: 'EXCO.DE',
+      name: 'Example Company AG',
+      industry: 'Auto Manufacturers',
+      exchange: 'XETRA'
+    });
+
+    const category = await symbolCategories.getSymbolCategory('EXCO.DE');
+
+    expect(category.company_name).toBe('Example Company AG');
+    expect(category.finnhub_industry).toBe('Auto Manufacturers');
+    expect(category.exchange).toBe('XETRA');
+  });
+
+  test('does not call Yahoo when billing is enabled', async () => {
+    TierService.isBillingEnabled.mockResolvedValue(true);
+    finnhub.getCompanyProfile.mockRejectedValue(planRestriction());
+
+    const category = await symbolCategories.getSymbolCategory('EXCO.DE');
+
+    expect(yahooFinance.getSymbolProfile).not.toHaveBeenCalled();
+    expect(category).toBeNull();
+  });
+
+  test('does not call Yahoo when the configured provider already answered', async () => {
+    finnhub.getCompanyProfile.mockResolvedValue({
+      name: 'Apple Inc', finnhubIndustry: 'Technology', exchange: 'NASDAQ'
+    });
+
+    const category = await symbolCategories.getSymbolCategory('AAPL');
+
+    expect(yahooFinance.getSymbolProfile).not.toHaveBeenCalled();
+    expect(category.company_name).toBe('Apple Inc');
+  });
+
+  test('skips the fallback rather than failing when the billing check throws', async () => {
+    TierService.isBillingEnabled.mockRejectedValue(new Error('instance_config unavailable'));
+    finnhub.getCompanyProfile.mockResolvedValue({ name: 'Apple Inc' });
+
+    const category = await symbolCategories.getSymbolCategory('AAPL');
+
+    expect(yahooFinance.getSymbolProfile).not.toHaveBeenCalled();
+    expect(category.company_name).toBe('Apple Inc');
+  });
+
+  test('does not spend a Yahoo request on an option contract symbol', async () => {
+    finnhub.getCompanyProfile.mockRejectedValue(planRestriction());
+
+    await symbolCategories.getSymbolCategory('SPY   260618P00350000');
+
+    expect(yahooFinance.getSymbolProfile).not.toHaveBeenCalled();
+  });
+
+  test('returns null rather than throwing when both providers fail', async () => {
+    finnhub.getCompanyProfile.mockRejectedValue(planRestriction());
+    yahooFinance.getSymbolProfile.mockRejectedValue(new Error('network down'));
+
+    await expect(symbolCategories.getSymbolCategory('EXCO.DE')).resolves.toBeNull();
+  });
+
+  test('returns null when neither provider knows the symbol', async () => {
+    finnhub.getCompanyProfile.mockResolvedValue(null);
+    yahooFinance.getSymbolProfile.mockResolvedValue(null);
+
+    await expect(symbolCategories.getSymbolCategory('NOSUCH.ZZ')).resolves.toBeNull();
+  });
+
+  test('keeps stored metadata when both providers fail', async () => {
+    storedRows([{ symbol: 'EXCO.DE', company_name: 'Example Company AG', finnhub_industry: null, updated_at: null }]);
+    finnhub.getCompanyProfile.mockRejectedValue(planRestriction());
+    yahooFinance.getSymbolProfile.mockRejectedValue(new Error('network down'));
+
+    const category = await symbolCategories.getSymbolCategory('EXCO.DE');
+
+    expect(category.company_name).toBe('Example Company AG');
+  });
+
+  test('does not spend a second request once the configured provider named the symbol', async () => {
+    finnhub.getCompanyProfile.mockResolvedValue({ name: 'Example Company AG' });
+
+    const category = await symbolCategories.getSymbolCategory('EXCO.DE');
+
+    expect(yahooFinance.getSymbolProfile).not.toHaveBeenCalled();
+    expect(category.company_name).toBe('Example Company AG');
+  });
+
+  test('fills the gaps when the configured provider returned an empty profile', async () => {
+    finnhub.getCompanyProfile.mockResolvedValue({ country: 'DE', currency: 'EUR' });
+    yahooFinance.getSymbolProfile.mockResolvedValue({
+      name: 'Example Company AG', industry: 'Auto Manufacturers', exchange: 'XETRA'
+    });
+
+    const category = await symbolCategories.getSymbolCategory('EXCO.DE');
+
+    expect(category.company_name).toBe('Example Company AG');
+    expect(category.finnhub_industry).toBe('Auto Manufacturers');
+    expect(category.country).toBe('DE');
+  });
+
+  test('an ETF with no industry is still worth a name', async () => {
+    finnhub.getCompanyProfile.mockRejectedValue(planRestriction());
+    yahooFinance.getSymbolProfile.mockResolvedValue({
+      name: 'EXAMPLE PHYSICAL GOLD', industry: null, exchange: 'LSE'
+    });
+
+    const category = await symbolCategories.getSymbolCategory('EXETF.L');
+
+    expect(category.company_name).toBe('EXAMPLE PHYSICAL GOLD');
+    expect(category.finnhub_industry).toBeNull();
+  });
+
+  test('a lookup that resolves nothing is still saved so it is not re-fetched', async () => {
+    finnhub.getCompanyProfile.mockResolvedValue({ name: null });
+    yahooFinance.getSymbolProfile.mockResolvedValue(null);
+
+    await symbolCategories.getSymbolCategory('NOSUCH.ZZ');
+
+    expect(db.query.mock.calls.some(([sql]) => sql.includes('INSERT INTO symbol_categories'))).toBe(true);
+  });
+});

--- a/backend/tests/utils/yahooFinance.profile.test.js
+++ b/backend/tests/utils/yahooFinance.profile.test.js
@@ -1,0 +1,112 @@
+jest.mock('axios', () => ({ get: jest.fn() }));
+jest.mock('../../src/utils/cache', () => ({
+  get: jest.fn(async () => null),
+  set: jest.fn(async () => true)
+}));
+
+const axios = require('axios');
+const yahooFinance = require('../../src/utils/yahooFinance');
+
+function searchResponse(quotes) {
+  return { data: { quotes } };
+}
+
+describe('Yahoo Finance symbol profiles', () => {
+  let originalEnabled;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    originalEnabled = process.env.YAHOO_FINANCE_ENABLED;
+    process.env.YAHOO_FINANCE_ENABLED = 'true';
+  });
+
+  afterEach(() => {
+    if (originalEnabled === undefined) delete process.env.YAHOO_FINANCE_ENABLED;
+    else process.env.YAHOO_FINANCE_ENABLED = originalEnabled;
+  });
+
+  test('returns industry and name for a listing the US-only provider cannot cover', async () => {
+    axios.get.mockResolvedValue(searchResponse([
+      { symbol: 'EXCO.DE', quoteType: 'EQUITY', sector: 'Consumer Cyclical', industry: 'Auto Manufacturers', longname: 'Example Company AG', exchDisp: 'XETRA' }
+    ]));
+
+    const profile = await yahooFinance.getSymbolProfile('EXCO.DE');
+
+    expect(profile.industry).toBe('Auto Manufacturers');
+    expect(profile.name).toContain('Example Company');
+    expect(profile.exchange).toBe('XETRA');
+  });
+
+  test('reports a null industry for an ETF rather than inventing one', async () => {
+    axios.get.mockResolvedValue(searchResponse([
+      { symbol: 'EXETF.L', quoteType: 'ETF', sector: null, industry: null, shortname: 'EXAMPLE PHYSICAL GOLD' }
+    ]));
+
+    const profile = await yahooFinance.getSymbolProfile('EXETF.L');
+
+    expect(profile.industry).toBeNull();
+    expect(profile.name).toBe('EXAMPLE PHYSICAL GOLD');
+  });
+
+  test('ignores a fuzzy match on a different ticker', async () => {
+    // Search is fuzzy; without an exact check a typo adopts a neighbour's sector.
+    axios.get.mockResolvedValue(searchResponse([
+      { symbol: 'EXCO.F', quoteType: 'EQUITY', sector: 'Consumer Cyclical', shortname: 'Example Co Frankfurt' }
+    ]));
+
+    expect(await yahooFinance.getSymbolProfile('EXCO.DE')).toBeNull();
+  });
+
+  test('translates the symbol before searching', async () => {
+    axios.get.mockResolvedValue(searchResponse([
+      { symbol: '^XSP', quoteType: 'INDEX', shortname: 'Mini SPX' }
+    ]));
+
+    await yahooFinance.getSymbolProfile('XSP');
+
+    expect(axios.get.mock.calls[0][1].params.q).toBe('^XSP');
+  });
+
+  test('never throws when the search fails', async () => {
+    axios.get.mockRejectedValue(new Error('network down'));
+    expect(await yahooFinance.getSymbolProfile('EXCO.DE')).toBeNull();
+  });
+
+  test('returns null when nothing matches', async () => {
+    axios.get.mockResolvedValue(searchResponse([]));
+    expect(await yahooFinance.getSymbolProfile('NOPE.ZZ')).toBeNull();
+  });
+});
+
+describe('Yahoo Finance profile caching', () => {
+  const cache = require('../../src/utils/cache');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.YAHOO_FINANCE_ENABLED = 'true';
+  });
+
+  test('records a miss so an unknown symbol is not re-queried every time', async () => {
+    axios.get.mockResolvedValue(searchResponse([]));
+
+    expect(await yahooFinance.getSymbolProfile('NOSUCH.L')).toBeNull();
+    expect(cache.set).toHaveBeenCalledWith(
+      'yahoo_symbol_profile', 'NOSUCH.L', { miss: true }
+    );
+  });
+
+  test('reads a recorded miss without calling the provider again', async () => {
+    cache.get.mockResolvedValue({ miss: true });
+
+    expect(await yahooFinance.getSymbolProfile('NOSUCH.L')).toBeNull();
+    expect(axios.get).not.toHaveBeenCalled();
+  });
+
+  test('still returns a cached hit', async () => {
+    cache.get.mockResolvedValue({ symbol: 'EXCO.DE', name: 'Example Company AG', industry: 'Auto Manufacturers' });
+
+    const profile = await yahooFinance.getSymbolProfile('EXCO.DE');
+    expect(profile.name).toBe('Example Company AG');
+    expect(axios.get).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/utils/yahooFinance.profile.test.js
+++ b/backend/tests/utils/yahooFinance.profile.test.js
@@ -49,7 +49,6 @@ describe('Yahoo Finance symbol profiles', () => {
   });
 
   test('ignores a fuzzy match on a different ticker', async () => {
-    // Search is fuzzy; without an exact check a typo adopts a neighbour's sector.
     axios.get.mockResolvedValue(searchResponse([
       { symbol: 'EXCO.F', quoteType: 'EQUITY', sector: 'Consumer Cyclical', shortname: 'Example Co Frankfurt' }
     ]));
@@ -83,6 +82,7 @@ describe('Yahoo Finance profile caching', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    cache.get.mockResolvedValue(null);
     process.env.YAHOO_FINANCE_ENABLED = 'true';
   });
 
@@ -100,6 +100,36 @@ describe('Yahoo Finance profile caching', () => {
 
     expect(await yahooFinance.getSymbolProfile('NOSUCH.L')).toBeNull();
     expect(axios.get).not.toHaveBeenCalled();
+  });
+
+  test('records a miss when the chart carries no name', async () => {
+    axios.get.mockResolvedValue({ data: { chart: { result: [{ meta: {} }] } } });
+
+    expect(await yahooFinance.getSymbolName('NONAME.L')).toBeNull();
+    expect(cache.set).toHaveBeenCalledWith(
+      'yahoo_symbol_name', 'NONAME.L', { miss: true }
+    );
+  });
+
+  test('reads a recorded name miss without calling the provider again', async () => {
+    cache.get.mockResolvedValue({ miss: true });
+
+    expect(await yahooFinance.getSymbolName('NONAME.L')).toBeNull();
+    expect(axios.get).not.toHaveBeenCalled();
+  });
+
+  test('still returns a cached name', async () => {
+    cache.get.mockResolvedValue('Example Company AG');
+
+    expect(await yahooFinance.getSymbolName('EXCO.DE')).toBe('Example Company AG');
+    expect(axios.get).not.toHaveBeenCalled();
+  });
+
+  test('does not cache a transient name lookup failure', async () => {
+    axios.get.mockRejectedValue(new Error('network down'));
+
+    expect(await yahooFinance.getSymbolName('EXCO.DE')).toBeNull();
+    expect(cache.set).not.toHaveBeenCalled();
   });
 
   test('still returns a cached hit', async () => {

--- a/frontend/src/components/common/StockLogo.test.js
+++ b/frontend/src/components/common/StockLogo.test.js
@@ -1,0 +1,102 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/composables/useSymbolMetadata', async () => {
+  const { reactive } = await import('vue')
+  const metadataBySymbol = reactive({})
+
+  return {
+    useSymbolMetadata: () => ({
+      metadataBySymbol,
+      ensureSymbolMetadata: vi.fn(),
+      normalizeSymbol: (symbol) => (typeof symbol === 'string' ? symbol.trim().toUpperCase() : '')
+    })
+  }
+})
+
+import { useSymbolMetadata } from '@/composables/useSymbolMetadata'
+import StockLogo from './StockLogo.vue'
+
+const { metadataBySymbol } = useSymbolMetadata()
+
+function clearMetadata() {
+  for (const key of Object.keys(metadataBySymbol)) delete metadataBySymbol[key]
+}
+
+async function failCurrentImage(wrapper) {
+  await wrapper.get('img').trigger('error')
+  await nextTick()
+}
+
+describe('StockLogo', () => {
+  beforeEach(clearMetadata)
+
+  it('walks the CDN candidates before landing on initials', async () => {
+    const wrapper = mount(StockLogo, { props: { symbol: 'EXCO.DE' } })
+
+    expect(wrapper.get('img').attributes('src')).toContain('parqet.com')
+    await failCurrentImage(wrapper)
+    expect(wrapper.get('img').attributes('src')).toContain('financialmodelingprep.com')
+    await failCurrentImage(wrapper)
+
+    expect(wrapper.find('img').exists()).toBe(false)
+    expect(wrapper.text()).toBe('EX')
+  })
+
+  it('tries a provider logo that arrives after the CDN candidates failed', async () => {
+    const wrapper = mount(StockLogo, { props: { symbol: 'EXCO.DE' } })
+
+    await failCurrentImage(wrapper)
+    await failCurrentImage(wrapper)
+    expect(wrapper.find('img').exists()).toBe(false)
+
+    metadataBySymbol['EXCO.DE'] = { symbol: 'EXCO.DE', logo: 'https://provider.example/exco.png' }
+    await flushPromises()
+
+    expect(wrapper.get('img').attributes('src')).toBe('https://provider.example/exco.png')
+  })
+
+  it('falls back to the CDNs again when the late provider logo also fails', async () => {
+    const wrapper = mount(StockLogo, { props: { symbol: 'EXCO.DE' } })
+
+    await failCurrentImage(wrapper)
+    await failCurrentImage(wrapper)
+
+    metadataBySymbol['EXCO.DE'] = { symbol: 'EXCO.DE', logo: 'https://provider.example/exco.png' }
+    await flushPromises()
+    await failCurrentImage(wrapper)
+
+    expect(wrapper.get('img').attributes('src')).toContain('parqet.com')
+  })
+
+  it('restarts the candidate list when the symbol changes', async () => {
+    const wrapper = mount(StockLogo, { props: { symbol: 'EXCO.DE' } })
+
+    await failCurrentImage(wrapper)
+    expect(wrapper.get('img').attributes('src')).toContain('financialmodelingprep.com')
+
+    await wrapper.setProps({ symbol: 'OTHER.L' })
+    await nextTick()
+
+    const src = wrapper.get('img').attributes('src')
+    expect(src).toContain('parqet.com')
+    expect(src).toContain('OTHER.L')
+  })
+
+  it('shows the company name on hover once metadata resolves', async () => {
+    const wrapper = mount(StockLogo, { props: { symbol: 'EXCO.DE' } })
+
+    metadataBySymbol['EXCO.DE'] = { symbol: 'EXCO.DE', companyName: 'Example Company AG', logo: null }
+    await flushPromises()
+
+    expect(wrapper.get('img').attributes('title')).toBe('Example Company AG')
+  })
+
+  it('has no CDN candidate for an option contract symbol', () => {
+    const wrapper = mount(StockLogo, { props: { symbol: 'TSLA 2026-06-18 350P' } })
+
+    expect(wrapper.find('img').exists()).toBe(false)
+    expect(wrapper.text()).toBe('TS')
+  })
+})

--- a/frontend/src/components/common/StockLogo.vue
+++ b/frontend/src/components/common/StockLogo.vue
@@ -3,13 +3,15 @@
     v-if="resolvedLogo"
     :src="resolvedLogo"
     :alt="altText"
+    :title="companyName || undefined"
     :class="imageClasses"
-    @error="imageFailed = true"
+    @error="handleImageError"
   />
   <div
     v-else
     :class="fallbackClasses"
     :aria-label="altText"
+    :title="companyName || undefined"
   >
     <span :class="fallbackTextClass">
       {{ fallbackText }}
@@ -20,6 +22,7 @@
 <script setup>
 import { computed, ref, watch } from 'vue'
 import { useSymbolMetadata } from '@/composables/useSymbolMetadata'
+import { fallbackLogoUrls } from '@/utils/symbolLogo'
 
 const props = defineProps({
   symbol: {
@@ -48,18 +51,28 @@ const props = defineProps({
   }
 })
 
-const imageFailed = ref(false)
+const failedCandidates = ref(0)
 const { metadataBySymbol, normalizeSymbol } = useSymbolMetadata(computed(() => props.symbol))
 
 const normalizedSymbol = computed(() => normalizeSymbol(props.symbol))
 const metadata = computed(() => metadataBySymbol[normalizedSymbol.value] || null)
-const resolvedLogo = computed(() => {
-  if (imageFailed.value) {
-    return null
-  }
 
-  return props.logoUrl || metadata.value?.logo || null
+// Ordered candidates: whatever the provider gave us, then the keyless CDNs.
+// Each failure advances to the next; running out lands on the initials.
+const logoCandidates = computed(() => {
+  const provided = props.logoUrl || metadata.value?.logo || null
+  const candidates = provided ? [provided] : []
+  return candidates.concat(fallbackLogoUrls(normalizedSymbol.value))
 })
+
+const resolvedLogo = computed(() => logoCandidates.value[failedCandidates.value] || null)
+
+function handleImageError() {
+  failedCandidates.value += 1
+}
+// The metadata endpoint resolves a name for listings the chart provider does
+// not cover; nothing in the trade views displayed it, so expose it on hover.
+const companyName = computed(() => metadata.value?.companyName || metadata.value?.company_name || null)
 const altText = computed(() => props.alt || `${normalizedSymbol.value || 'Stock'} logo`)
 const fallbackText = computed(() => (normalizedSymbol.value || '?').slice(0, 2))
 const imageClasses = computed(() => `${props.sizeClass} ${props.roundedClass} object-contain bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 flex-shrink-0`)
@@ -68,7 +81,7 @@ const fallbackClasses = computed(() => `${props.sizeClass} ${props.roundedClass}
 watch(
   () => [props.symbol, props.logoUrl],
   () => {
-    imageFailed.value = false
+    failedCandidates.value = 0
   }
 )
 </script>

--- a/frontend/src/components/common/StockLogo.vue
+++ b/frontend/src/components/common/StockLogo.vue
@@ -57,11 +57,11 @@ const { metadataBySymbol, normalizeSymbol } = useSymbolMetadata(computed(() => p
 const normalizedSymbol = computed(() => normalizeSymbol(props.symbol))
 const metadata = computed(() => metadataBySymbol[normalizedSymbol.value] || null)
 
-// Ordered candidates: whatever the provider gave us, then the keyless CDNs.
-// Each failure advances to the next; running out lands on the initials.
+const providedLogo = computed(() => props.logoUrl || metadata.value?.logo || null)
+
+// Provider logo first, then the keyless CDNs; running out lands on the initials.
 const logoCandidates = computed(() => {
-  const provided = props.logoUrl || metadata.value?.logo || null
-  const candidates = provided ? [provided] : []
+  const candidates = providedLogo.value ? [providedLogo.value] : []
   return candidates.concat(fallbackLogoUrls(normalizedSymbol.value))
 })
 
@@ -70,16 +70,16 @@ const resolvedLogo = computed(() => logoCandidates.value[failedCandidates.value]
 function handleImageError() {
   failedCandidates.value += 1
 }
-// The metadata endpoint resolves a name for listings the chart provider does
-// not cover; nothing in the trade views displayed it, so expose it on hover.
+
 const companyName = computed(() => metadata.value?.companyName || metadata.value?.company_name || null)
 const altText = computed(() => props.alt || `${normalizedSymbol.value || 'Stock'} logo`)
 const fallbackText = computed(() => (normalizedSymbol.value || '?').slice(0, 2))
 const imageClasses = computed(() => `${props.sizeClass} ${props.roundedClass} object-contain bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 flex-shrink-0`)
 const fallbackClasses = computed(() => `${props.sizeClass} ${props.roundedClass} bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-300 inline-flex items-center justify-center flex-shrink-0`)
 
+// providedLogo resolves after mount, so reset or the late logo is indexed past.
 watch(
-  () => [props.symbol, props.logoUrl],
+  () => [props.symbol, providedLogo.value],
   () => {
     failedCandidates.value = 0
   }

--- a/frontend/src/utils/symbolLogo.js
+++ b/frontend/src/utils/symbolLogo.js
@@ -1,0 +1,22 @@
+// Finnhub's free tier only covers US listings, so every non-US holding arrives
+// from /symbols/metadata with no logo at all — a German or LSE ticker would
+// otherwise fall back to two grey initials. These CDNs need no API key and
+// return a clean 404 for tickers they do not know, which the <img> error
+// handler turns into the next candidate and finally back into initials.
+//
+// Parqet is tried first: it serves SVG (crisp at any size) and the real marks
+// where FMP has only a wordmark.
+const LOGO_CDNS = [
+  (symbol) => `https://assets.parqet.com/logos/symbol/${encodeURIComponent(symbol)}`,
+  (symbol) => `https://images.financialmodelingprep.com/symbol/${encodeURIComponent(symbol)}.png`,
+]
+
+// Plain listed tickers only: option contract symbols and CUSIPs would never
+// resolve, and asking for them just spends a request to get a 404.
+const LISTED_SYMBOL = /^[A-Z0-9]{1,8}(?:[.-][A-Z0-9]{1,4})?$/
+
+export function fallbackLogoUrls(symbol) {
+  const normalized = String(symbol || '').trim().toUpperCase()
+  if (!normalized || !LISTED_SYMBOL.test(normalized)) return []
+  return LOGO_CDNS.map((build) => build(normalized))
+}

--- a/frontend/src/utils/symbolLogo.js
+++ b/frontend/src/utils/symbolLogo.js
@@ -1,18 +1,11 @@
-// Finnhub's free tier only covers US listings, so every non-US holding arrives
-// from /symbols/metadata with no logo at all — a German or LSE ticker would
-// otherwise fall back to two grey initials. These CDNs need no API key and
-// return a clean 404 for tickers they do not know, which the <img> error
-// handler turns into the next candidate and finally back into initials.
-//
-// Parqet is tried first: it serves SVG (crisp at any size) and the real marks
-// where FMP has only a wordmark.
+// Keyless logo CDNs for the non-US listings the provider has no logo for.
+// Parqet first: it serves SVG and the real marks where FMP has only a wordmark.
 const LOGO_CDNS = [
   (symbol) => `https://assets.parqet.com/logos/symbol/${encodeURIComponent(symbol)}`,
   (symbol) => `https://images.financialmodelingprep.com/symbol/${encodeURIComponent(symbol)}.png`,
 ]
 
-// Plain listed tickers only: option contract symbols and CUSIPs would never
-// resolve, and asking for them just spends a request to get a 404.
+// Plain listed tickers only; option symbols and CUSIPs would just earn a 404.
 const LISTED_SYMBOL = /^[A-Z0-9]{1,8}(?:[.-][A-Z0-9]{1,4})?$/
 
 export function fallbackLogoUrls(symbol) {

--- a/frontend/src/utils/symbolLogo.test.js
+++ b/frontend/src/utils/symbolLogo.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'vitest'
+import { fallbackLogoUrls } from './symbolLogo'
+
+describe('fallbackLogoUrls', () => {
+  test('prefers Parqet, then falls back to FMP', () => {
+    const [first, second] = fallbackLogoUrls('EXCO')
+    expect(first).toContain('parqet.com')
+    expect(second).toContain('financialmodelingprep.com')
+  })
+
+  test('keeps the exchange suffix that non-US listings need', () => {
+    for (const symbol of ['EXCO.DE', 'EXETF.L', 'EXETF.DE']) {
+      const urls = fallbackLogoUrls(symbol)
+      expect(urls).toHaveLength(2)
+      expect(urls.every((url) => url.includes(symbol))).toBe(true)
+    }
+  })
+
+  test('upper-cases a lowercase symbol', () => {
+    expect(fallbackLogoUrls('exco.de')[0]).toContain('EXCO.DE')
+  })
+
+  test('handles class shares', () => {
+    expect(fallbackLogoUrls('BRK-B')[0]).toContain('BRK-B')
+  })
+
+  test('declines option contract symbols rather than spending a request', () => {
+    expect(fallbackLogoUrls('TSLA 2026-06-18 350P')).toEqual([])
+    expect(fallbackLogoUrls('SPY   260618P00350000')).toEqual([])
+  })
+
+  test('declines empty or malformed input', () => {
+    expect(fallbackLogoUrls('')).toEqual([])
+    expect(fallbackLogoUrls(null)).toEqual([])
+    expect(fallbackLogoUrls(undefined)).toEqual([])
+  })
+})

--- a/frontend/src/views/trades/TradeDetailView.vue
+++ b/frontend/src/views/trades/TradeDetailView.vue
@@ -20,13 +20,22 @@
     <div v-else-if="trade" class="space-y-8">
       <!-- Header -->
       <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h1 class="heading-page">
-            {{ trade.symbol }} Trade
-          </h1>
-          <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-            {{ formatDate(trade.trade_date) }} • {{ trade.side }}
-          </p>
+        <div class="flex items-center gap-3">
+          <StockLogo
+            :symbol="trade.symbol"
+            size-class="w-11 h-11"
+            fallback-text-class="text-sm font-semibold"
+          />
+          <div class="min-w-0">
+            <h1 class="heading-page">
+              {{ trade.symbol }} Trade
+            </h1>
+            <p class="mt-1 truncate text-sm text-gray-600 dark:text-gray-400">
+              <!-- The company name leads when we have one: the ticker above is
+                   the identifier, this line says what it actually is. -->
+              <span v-if="symbolCompanyName">{{ symbolCompanyName }} • </span>{{ formatDate(trade.trade_date) }} • {{ trade.side }}
+            </p>
+          </div>
         </div>
         <div v-if="isOwner" class="flex flex-wrap gap-3 sm:justify-end">
           <button
@@ -1612,6 +1621,8 @@ import { DocumentIcon, ChatBubbleLeftIcon, SparklesIcon, ShareIcon, TrashIcon, P
 import { useCurrencyFormatter } from '@/composables/useCurrencyFormatter'
 import api from '@/services/api'
 import { useAuthStore } from '@/stores/auth'
+import StockLogo from '@/components/common/StockLogo.vue'
+import { useSymbolMetadata } from '@/composables/useSymbolMetadata'
 import TradeChartVisualization from '@/components/trades/TradeChartVisualization.vue'
 import TradeImages from '@/components/trades/TradeImages.vue'
 import TradeCharts from '@/components/trades/TradeCharts.vue'
@@ -1710,6 +1721,14 @@ function hasLegacyFuturesExcursionUnits(currentTrade, captured, scale) {
 
 const loading = ref(true)
 const trade = ref(null)
+
+// Company name for the header subtitle. Resolved through the shared metadata
+// store, which backfills non-US listings the chart provider does not cover.
+const { metadataBySymbol, normalizeSymbol } = useSymbolMetadata(computed(() => trade.value?.symbol || ''))
+const symbolCompanyName = computed(() => {
+  const symbol = normalizeSymbol(trade.value?.symbol || '')
+  return symbol ? (metadataBySymbol[symbol]?.companyName || null) : null
+})
 
 // True only for the trade's owner. Guests/other users viewing a public trade get
 // a read-only view: owner actions and owner-only data fetches are skipped.

--- a/frontend/src/views/trades/TradeDetailView.vue
+++ b/frontend/src/views/trades/TradeDetailView.vue
@@ -31,8 +31,6 @@
               {{ trade.symbol }} Trade
             </h1>
             <p class="mt-1 truncate text-sm text-gray-600 dark:text-gray-400">
-              <!-- The company name leads when we have one: the ticker above is
-                   the identifier, this line says what it actually is. -->
               <span v-if="symbolCompanyName">{{ symbolCompanyName }} • </span>{{ formatDate(trade.trade_date) }} • {{ trade.side }}
             </p>
           </div>
@@ -1722,8 +1720,6 @@ function hasLegacyFuturesExcursionUnits(currentTrade, captured, scale) {
 const loading = ref(true)
 const trade = ref(null)
 
-// Company name for the header subtitle. Resolved through the shared metadata
-// store, which backfills non-US listings the chart provider does not cover.
 const { metadataBySymbol, normalizeSymbol } = useSymbolMetadata(computed(() => trade.value?.symbol || ''))
 const symbolCompanyName = computed(() => {
   const symbol = normalizeSymbol(trade.value?.symbol || '')


### PR DESCRIPTION
Finnhub's free tier covers US listings only, so stock/profile2 returns 403 for a non-US symbol. Those holdings had no company name, no logo and no industry, rendering as two grey initials and dropping out of every view grouped by it.

- A 403 for a plan restriction aborted the whole lookup in symbolCategories, so the symbol could never acquire metadata from anywhere else; the provider call is contained so it degrades instead
- Names and industries fall back to Yahoo, which needs no key and covers these venues. Its search endpoint is used rather than quoteSummary, which now demands a crumb; search is fuzzy, so only an exact ticker match is accepted, or a symbol adopts a neighbouring listing's industry. Yahoo also reports a sector, which is a broader classification and is deliberately not used: finnhub_industry holds an industry, and filling it with a sector would mix the two
- an observation in the existing main branch is that TradeDetailView labels Industry as "Sector". This is not something this pull request introduces.
- A symbol Yahoo does not know is recorded as a miss rather than re-queried on every request, and an ETF legitimately has no industry, so none is recorded rather than retried forever. Exchange comes along with it
- The fallback is self-hosted only, matching the gate the chart fallbacks use, and runs in bounded batches rather than one request per symbol at once
- Logos fall back to keyless CDNs when the provider has none or serves one that fails to load, with initials as the last resort. Both CDNs 404 cleanly for unknown tickers, and option symbols are declined outright rather than spending a request to earn a 404
- useSymbolMetadata was consumed only by StockLogo, so the API alone showed nothing; the trade detail header now carries logo and name. The name is a subtitle, not the heading, because a long fund name wraps and pushes the actions off screen on mobile

Logo requests disclose held tickers to those CDNs, as the existing provider logos already do for US symbols.